### PR TITLE
Upgraded proxygen.

### DIFF
--- a/prov-shit/ansible/roles/base/builder/defaults/main.yml
+++ b/prov-shit/ansible/roles/base/builder/defaults/main.yml
@@ -1,8 +1,8 @@
 proxygen_install_dir: "{{home}}/proxygen"
-proxygen_version: "db6ecda00341a41ed91bf70553ccfc0b9b7aacb3"
+proxygen_version: "069658dc76ae41396fe106c24953837c42711584"
 
 folly_install_dir: "{{home}}/proxygen/proxygen/folly"
-folly_version: "75e5507cbfe7ef5a448375e9908e10864b506b05"
+folly_version: "f6b5f78bd533b91f51c3afc6d310698a42edb65d"
 
 wangle_install_dir: "{{home}}/proxygen/proxygen/wangle"
-wangle_version: "abd50dd21231483d49ce335dbd5e6e5ef516b87d"
+wangle_version: "2c55f2bdcc84216c26c6058e754b874c3029e39f"

--- a/prov-shit/ansible/roles/base/builder/tasks/main.yml
+++ b/prov-shit/ansible/roles/base/builder/tasks/main.yml
@@ -36,7 +36,7 @@
   tags: isaac
 
 - name: Get Proxygen
-  git: repo=https://github.com/facebook/proxygen.git dest={{proxygen_install_dir}} version={{proxygen_version}}
+  git: repo=https://github.com/facebook/proxygen.git dest={{proxygen_install_dir}} version={{proxygen_version}} force=yes
   tags: isaac
 
 - name: Get Folly
@@ -75,6 +75,10 @@
   sudo: true
   with_items:
     - glide
+
+- name: Install Package for Ansible Lint
+  apt: name=libffi-dev state=latest force=yes
+  sudo: true
 
 - name: Install ansible-lint
   pip: name=ansible-lint

--- a/prov-shit/ansible/vagrant_builder.yml
+++ b/prov-shit/ansible/vagrant_builder.yml
@@ -3,23 +3,13 @@
 - name: Environment that can build All The Things
   hosts: all
   vars:
-    ashes_server_name: admin.local.foxcommerce.com
-    storefront_server_name: local.foxcommerce.com
+      user: vagrant
   roles:
     - { role: base/common }
-    - { role: base/consul }
     - { role: base/ssh_keys }
     - { role: base/scala }
-    - { role: base/confluence }
-    - { role: base/zookeeper }
-    - { role: base/kafka }
-    - { role: base/schema-registry }
-    - { role: base/elasticsearch }
-    - { role: base/db }
-    - { role: base/rsyslog, sudo: yes }
-    - { role: base/kibana, sudo: yes }
     - { role: base/node }
-    - { role: base/balancer, sudo: yes }
+    - { role: test/db }
     - { role: base/builder }
 
   handlers:


### PR DESCRIPTION
Proxygen depends on wangle library. Wangle uses gmock and downloaded it during
build from google code.

Google code shut down so the download failed, breaking the build. New versions of
fixed this problem.

So upgrading solved it.

Also ansible-lint was failing and I had to add a lib dependency.