### PR TITLE
Use updated appliance base

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -113,7 +113,6 @@ Vagrant.configure("2") do |config|
   config.vm.define :appliance, primary: true do |app|
     app.vm.box = "base_appliance_16.04_20160914"
     app.vm.box_url = "https://s3.amazonaws.com/fc-dev-boxes/base_appliance_16.04_20160914.box"
-
     app.vm.network :private_network, ip: $nginx_ip
     expose_ports(app)
 


### PR DESCRIPTION
`PROJECTS=(ashes firebrand fox-notifications green-river integration-tests isaac middlewarehouse phoenix-scala prov-shit)`
- [x] Remove `sudo` from unzipping Avro that was breaking provisioning
- [x] Use an updated appliance base (previous had a broken bottledwater reference)
