### PR TITLE
Update API docs to match variants payload format

### DIFF
--- a/phoenix-scala/docs/api/docs/admin_products.apib
+++ b/phoenix-scala/docs/api/docs/admin_products.apib
@@ -67,8 +67,7 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [1]
+              ]
             }, {
               "attributes": {
                 "code": {
@@ -93,22 +92,28 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [2]
+              ]
             }
           ],
           "variants": [
             {
-              "name": "Color",
+              "attributes": {
+                "name": {
+                  "t": "string",
+                  "v": "Color"
+                }
+              },
               "values": [
                 {
                   "id": 1,
                   "name": "Red",
-                  "swatch": "FF0000"
+                  "swatch": "FF0000",
+                  "skuCodes": ["FOX-RED"]
                 }, {
                   "id": 2,
                   "name": "Blue",
-                  "swatch": "0000FF"
+                  "swatch": "0000FF",
+                  "skuCodes": ["FOX-BLUE"]
                 }
               ]
             }
@@ -168,14 +173,21 @@ and merchandised with custom content and images.
           ],
           "variants": [
             {
-              "name": "Color",
+              "attributes": {
+                "name": {
+                  "t": "string",
+                  "v": "Color"
+                }
+              },
               "values": [
                 {
                   "name": "Red",
-                  "swatch": "FF0000"
+                  "swatch": "FF0000",
+                  "skuCodes": ["FOX-RED"]
                 }, {
                   "name": "Blue",
-                  "swatch": "0000FF"
+                  "swatch": "0000FF",
+                  "skuCodes": ["FOX-BLUE"]
                 }
               ]
             }
@@ -239,8 +251,7 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [1]
+              ]
             }, {
               "attributes": {
                 "code": {
@@ -265,22 +276,28 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [2]
+              ]
             }
           ],
           "variants": [
             {
-              "name": "Color",
+              "attributes": {
+                "name": {
+                  "t": "string",
+                  "v": "Color"
+                }
+              },
               "values": [
                 {
                   "id": 1,
                   "name": "Red",
-                  "swatch": "FF0000"
+                  "swatch": "FF0000",
+                  "skuCodes": ["FOX-RED"]
                 }, {
                   "id": 2,
                   "name": "Blue",
-                  "swatch": "0000FF"
+                  "swatch": "0000FF",
+                  "skuCodes": ["FOX-BLUE"]
                 }
               ]
             }
@@ -335,14 +352,23 @@ and merchandised with custom content and images.
           ],
           "variants": [
             {
-              "name": "Color",
+              "attributes": {
+                "name": {
+                  "t": "string",
+                  "v": "Color"
+                }
+              },
               "values": [
                 {
+                  "id": 1,
                   "name": "Red",
-                  "swatch": "FF0000"
+                  "swatch": "FF0000",
+                  "skuCodes": ["FOX-RED"]
                 }, {
+                  "id": 2,
                   "name": "Blue",
-                  "swatch": "0000FF"
+                  "swatch": "0000FF",
+                  "skuCodes": ["FOX-BLUE"]
                 }
               ]
             }
@@ -403,8 +429,7 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [1]
+              ]
             }, {
               "code": "FOX-BLUE",
               "attributes": {
@@ -426,22 +451,28 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [2]
+              ]
             }
           ],
           "variants": [
             {
-              "name": "Color",
+              "attributes": {
+                "name": {
+                  "t": "string",
+                  "v": "Color"
+                }
+              },
               "values": [
                 {
                   "id": 1,
                   "name": "Red",
-                  "swatch": "FF0000"
+                  "swatch": "FF0000",
+                  "skuCodes": ["FOX-RED"]
                 }, {
                   "id": 2,
                   "name": "Blue",
-                  "swatch": "0000FF"
+                  "swatch": "0000FF",
+                  "skuCodes": ["FOX-BLUE"]
                 }
               ]
             }
@@ -507,8 +538,7 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [1]
+              ]
             }, {
               "attributes": {
                 "code": {
@@ -533,22 +563,28 @@ and merchandised with custom content and images.
                     }
                   ]
                 }
-              ],
-              "variantValueIds": [2]
+              ]
             }
           ],
           "variants": [
             {
-              "name": "Color",
+              "attributes": {
+                "name": {
+                  "t": "string",
+                  "v": "Color"
+                }
+              },
               "values": [
                 {
                   "id": 1,
                   "name": "Red",
-                  "swatch": "FF0000"
+                  "swatch": "FF0000",
+                  "skuCodes": ["FOX-RED"]
                 }, {
                   "id": 2,
                   "name": "Blue",
-                  "swatch": "0000FF"
+                  "swatch": "0000FF",
+                  "skuCodes": ["FOX-BLUE"]
                 }
               ]
             }


### PR DESCRIPTION
- Variant properties (such as name) are part of attributes
- Variant values should contain the mapping to SKUs, not the other way around