### PR TITLE
Set proper BK agent IDs after terraforming

### DIFF
--- a/prov-shit/terraform/modules/gce/agent/main.tf
+++ b/prov-shit/terraform/modules/gce/agent/main.tf
@@ -27,4 +27,10 @@ resource "google_compute_instance" "agent" {
         user = "${var.ssh_user}"
         private_key = "${file(var.ssh_private_key)}"
     }
+
+    provisioner "remote-exec" {
+        inline = [
+          "sudo systemctl restart buildkite-agent"
+        ]
+    }
 }

--- a/prov-shit/terraform/modules/gce/amigos/main.tf
+++ b/prov-shit/terraform/modules/gce/amigos/main.tf
@@ -43,5 +43,4 @@ resource "google_compute_instance" "amigo_server" {
           "sudo su -c 'echo ${count.index + 1} > /var/lib/zookeeper/myid'"
         ]
     }
-
 }


### PR DESCRIPTION
BuildKite agents are using `os.Hostname` as ID, and since we started packing them, they were grabbing UUID's generated by packer. Simple restart after launching machine will re-read proper hostname.