### PR TITLE
Handle new JWTs in Firebrand with new API.js

### DIFF
--- a/firebrand/package.json
+++ b/firebrand/package.json
@@ -74,7 +74,7 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
-    "api-js": "github:foxcomm/api-js#v0.4.0",
+    "api-js": "file:../api-js",
     "classnames": "^2.2.3",
     "core-decorators": "^0.11.0",
     "currency-symbol-map": "^2.2.0",

--- a/firebrand/server/verify-jwt.js
+++ b/firebrand/server/verify-jwt.js
@@ -21,7 +21,7 @@ export default function *verifyJwt(next) {
     try {
       decodedToken = jsonwebtoken.verify(jwt, publicKey, {
         issuer: 'FC',
-        audience: 'customer',
+        audience: 'user',
         algorithms: ['RS256', 'RS384', 'RS512'],
       });
     } catch (err) {


### PR DESCRIPTION
- [x] Use highlander api.js that supports the new JWT
- [x] Correctly validate the audience with the JWT