### PR TITLE
Group line items for order and cart in admin.

### DIFF
--- a/phoenix-scala/app/models/cord/lineitems/CartLineItem.scala
+++ b/phoenix-scala/app/models/cord/lineitems/CartLineItem.scala
@@ -20,6 +20,8 @@ case class CartLineItemProductData(sku: Sku,
 
   def lineItemReferenceNumber = lineItem.referenceNumber
   def lineItemState           = OrderLineItem.Cart
+  def withLineItemReferenceNumber(newLineItemRef: String) =
+    this.copy(lineItem = lineItem.copy(referenceNumber = newLineItemRef))
 }
 
 case class CartLineItem(id: Int = 0, referenceNumber: String = "", cordRef: String, skuId: Int)

--- a/phoenix-scala/app/models/cord/lineitems/OrderLineItem.scala
+++ b/phoenix-scala/app/models/cord/lineitems/OrderLineItem.scala
@@ -26,6 +26,7 @@ trait LineItemProductData[LI] {
 
   def lineItemReferenceNumber: String
   def lineItemState: OrderLineItem.State
+  def withLineItemReferenceNumber(newLineItemRef: String): LineItemProductData[LI]
 }
 
 case class OrderLineItemProductData(sku: Sku,
@@ -38,6 +39,8 @@ case class OrderLineItemProductData(sku: Sku,
     extends LineItemProductData[OrderLineItem] {
   def lineItemReferenceNumber = lineItem.referenceNumber
   def lineItemState           = lineItem.state
+  def withLineItemReferenceNumber(newLineItemRef: String) =
+    this.copy(lineItem = lineItem.copy(referenceNumber = newLineItemRef))
 }
 
 case class OrderLineItem(id: Int = 0,

--- a/phoenix-scala/app/responses/ReturnResponse.scala
+++ b/phoenix-scala/app/responses/ReturnResponse.scala
@@ -235,8 +235,9 @@ object ReturnResponse {
     val orderQ: DbResultT[Option[OrderResponse]] = for {
       maybeOrder ← * <~ Orders.findByRefNum(rma.orderRef).one
       fullOrder ← * <~ ((maybeOrder, withOrder) match {
-                       case (Some(order), true) ⇒ OrderResponse.fromOrder(order).map(Some(_))
-                       case _                   ⇒ DbResultT.none[OrderResponse]
+                       case (Some(order), true) ⇒
+                         OrderResponse.fromOrder(order, grouped = true).map(Some(_))
+                       case _ ⇒ DbResultT.none[OrderResponse]
                      })
     } yield fullOrder
 

--- a/phoenix-scala/app/responses/cord/OrderResponse.scala
+++ b/phoenix-scala/app/responses/cord/OrderResponse.scala
@@ -36,12 +36,13 @@ case class OrderResponse(referenceNumber: String,
 
 object OrderResponse {
 
-  def fromOrder(order: Order)(implicit db: DB, ec: EC): DbResultT[OrderResponse] =
+  def fromOrder(order: Order, grouped: Boolean)(implicit db: DB,
+                                                ec: EC): DbResultT[OrderResponse] =
     for {
       context      ← * <~ ObjectContexts.mustFindById400(order.contextId)
       payState     ← * <~ OrderQueries.getPaymentState(order.refNum)
       lineItemAdj  ← * <~ CordResponseLineItemAdjustments.fetch(order.refNum)
-      lineItems    ← * <~ CordResponseLineItems.fetch(order.refNum, lineItemAdj)
+      lineItems    ← * <~ CordResponseLineItems.fetch(order.refNum, lineItemAdj, grouped)
       promo        ← * <~ CordResponsePromotions.fetch(order.refNum)(db, ec, context)
       customer     ← * <~ Users.findOneByAccountId(order.accountId)
       customerData ← * <~ CustomersData.findOneByAccountId(order.accountId)

--- a/phoenix-scala/app/responses/cord/base/CordResponseLineItems.scala
+++ b/phoenix-scala/app/responses/cord/base/CordResponseLineItems.scala
@@ -28,20 +28,22 @@ object CordResponseLineItems {
 
   type AdjustmentMap = Map[String, CordResponseLineItemAdjustment]
 
-  def fetch(cordRef: String, adjustments: Seq[CordResponseLineItemAdjustment])(
+  def fetch(cordRef: String, adjustments: Seq[CordResponseLineItemAdjustment], grouped: Boolean)(
       implicit ec: EC,
       db: DB): DbResultT[CordResponseLineItems] =
-    fetch(cordRef, adjustments, cordLineItemsFromOrder)
+    if (grouped) fetchLineItems(cordRef, adjustments, cordLineItemsFromOrderGrouped)
+    else fetchLineItems(cordRef, adjustments, cordLineItemsFromOrder)
 
   def fetchCart(cordRef: String,
                 adjustments: Seq[CordResponseLineItemAdjustment],
                 grouped: Boolean)(implicit ec: EC, db: DB): DbResultT[CordResponseLineItems] =
-    if (grouped) fetch(cordRef, adjustments, cordLineItemsFromCartGrouped)
-    else fetch(cordRef, adjustments, cordLineItemsFromCart)
+    if (grouped) fetchLineItems(cordRef, adjustments, cordLineItemsFromCartGrouped)
+    else fetchLineItems(cordRef, adjustments, cordLineItemsFromCart)
 
-  def fetch(cordRef: String,
-            adjustments: Seq[CordResponseLineItemAdjustment],
-            readLineItems: (String, AdjustmentMap) ⇒ DbResultT[Seq[CordResponseLineItem]])(
+  def fetchLineItems(cordRef: String,
+                     adjustments: Seq[CordResponseLineItemAdjustment],
+                     readLineItems: (String,
+                                     AdjustmentMap) ⇒ DbResultT[Seq[CordResponseLineItem]])(
       implicit ec: EC,
       db: DB): DbResultT[CordResponseLineItems] = {
     val adjustmentMap = mapAdjustments(adjustments)
@@ -56,17 +58,34 @@ object CordResponseLineItems {
       result ← * <~ li.map(data ⇒ createResponse(data, 1))
     } yield result
 
-  def cordLineItemsFromCartGrouped(cordRef: String, adjustmentMap: AdjustmentMap)(
+  def cordLineItemsGrouped(lineItems: Seq[LineItemProductData[_]],
+                           cordRef: String,
+                           adjustmentMap: AdjustmentMap)(
       implicit ec: EC,
       db: DB): DbResultT[Seq[CordResponseLineItem]] =
     for {
-      lineItems ← * <~ LineItemManager.getCartLineItems(cordRef)
       result ← * <~ lineItems
                 .groupBy(lineItem ⇒ groupKey(lineItem, adjustmentMap))
                 .map {
                   case (_, lineItemGroup) ⇒ createResponseGrouped(lineItemGroup, adjustmentMap)
                 }
                 .toSeq
+    } yield result
+
+  def cordLineItemsFromOrderGrouped(cordRef: String, adjustmentMap: AdjustmentMap)(
+      implicit ec: EC,
+      db: DB): DbResultT[Seq[CordResponseLineItem]] =
+    for {
+      lineItems ← * <~ LineItemManager.getOrderLineItems(cordRef)
+      result    ← * <~ cordLineItemsGrouped(lineItems, cordRef, adjustmentMap)
+    } yield result
+
+  def cordLineItemsFromCartGrouped(cordRef: String, adjustmentMap: AdjustmentMap)(
+      implicit ec: EC,
+      db: DB): DbResultT[Seq[CordResponseLineItem]] =
+    for {
+      lineItems ← * <~ LineItemManager.getCartLineItems(cordRef)
+      result    ← * <~ cordLineItemsGrouped(lineItems, cordRef, adjustmentMap)
     } yield result
 
   def cordLineItemsFromCart(cordRef: String, adjustmentMap: AdjustmentMap)(
@@ -86,7 +105,7 @@ object CordResponseLineItems {
 
   val NOT_ADJUSTED = "na"
 
-  private def groupKey(data: CartLineItemProductData,
+  private def groupKey(data: LineItemProductData[_],
                        adjMap: Map[String, CordResponseLineItemAdjustment]): String = {
     val prefix = data.sku.id
     val suffix =
@@ -98,7 +117,7 @@ object CordResponseLineItems {
   private val NO_IMAGE =
     "https://s3-us-west-2.amazonaws.com/fc-firebird-public/images/product/no_image.jpg"
 
-  private def createResponseGrouped(lineItemData: Seq[CartLineItemProductData],
+  private def createResponseGrouped(lineItemData: Seq[LineItemProductData[_]],
                                     adjMap: Map[String, CordResponseLineItemAdjustment])(
       implicit ec: EC,
       db: DB): CordResponseLineItem = {
@@ -115,8 +134,7 @@ object CordResponseLineItems {
         data.lineItemReferenceNumber
       else ""
 
-    createResponse(data.copy(lineItem = data.lineItem.copy(referenceNumber = referenceNumber)),
-                   lineItemData.length)
+    createResponse(data.withLineItemReferenceNumber(referenceNumber), lineItemData.length)
   }
 
   private def createResponse(data: LineItemProductData[_],

--- a/phoenix-scala/app/routes/admin/OrderRoutes.scala
+++ b/phoenix-scala/app/routes/admin/OrderRoutes.scala
@@ -43,7 +43,7 @@ object OrderRoutes {
         pathPrefix("carts" / cordRefNumRegex) { refNum ⇒
           (get & pathEnd) {
             getOrFailures {
-              CartQueries.findOne(refNum, grouped = false)
+              CartQueries.findOne(refNum)
             }
           }
         } ~

--- a/phoenix-scala/app/services/Checkout.scala
+++ b/phoenix-scala/app/services/Checkout.scala
@@ -111,7 +111,7 @@ case class Checkout(
       order     ← * <~ Orders.createFromCart(cart)
       _         ← * <~ fraudScore(order)
       _         ← * <~ updateCouponCountersForPromotion(customer)
-      fullOrder ← * <~ OrderResponse.fromOrder(order)
+      fullOrder ← * <~ OrderResponse.fromOrder(order, grouped = true)
       _         ← * <~ LogActivity.orderCheckoutCompleted(fullOrder)
     } yield fullOrder
 

--- a/phoenix-scala/app/services/orders/OrderQueries.scala
+++ b/phoenix-scala/app/services/orders/OrderQueries.scala
@@ -31,11 +31,13 @@ object OrderQueries extends CordQueries {
     } yield TheResponse.build(response)
   }
 
-  def findOne(
-      refNum: String)(implicit ec: EC, db: DB, ctx: OC): DbResultT[TheResponse[OrderResponse]] =
+  def findOne(refNum: String, grouped: Boolean = true)(
+      implicit ec: EC,
+      db: DB,
+      ctx: OC): DbResultT[TheResponse[OrderResponse]] =
     for {
       order    ← * <~ Orders.mustFindByRefNum(refNum)
-      response ← * <~ OrderResponse.fromOrder(order)
+      response ← * <~ OrderResponse.fromOrder(order, grouped)
     } yield TheResponse.build(response)
 
 }

--- a/phoenix-scala/app/services/orders/OrderStateUpdater.scala
+++ b/phoenix-scala/app/services/orders/OrderStateUpdater.scala
@@ -27,7 +27,7 @@ object OrderStateUpdater {
       _        ← * <~ order.transitionState(newState)
       _        ← * <~ updateQueries(admin, Seq(refNum), newState)
       updated  ← * <~ Orders.mustFindByRefNum(refNum)
-      response ← * <~ OrderResponse.fromOrder(updated)
+      response ← * <~ OrderResponse.fromOrder(updated, grouped = true)
       _        ← * <~ doOrMeh(order.state != newState, orderStateChanged(admin, response, order.state))
     } yield response
 

--- a/phoenix-scala/app/services/orders/OrderUpdater.scala
+++ b/phoenix-scala/app/services/orders/OrderUpdater.scala
@@ -19,7 +19,7 @@ object OrderUpdater {
       updated ← * <~ Orders.update(
                    order,
                    order.copy(remorsePeriodEnd = order.remorsePeriodEnd.map(_.plusMinutes(15))))
-      response ← * <~ OrderResponse.fromOrder(updated)
+      response ← * <~ OrderResponse.fromOrder(updated, grouped = true)
       _        ← * <~ LogActivity.orderRemorsePeriodIncreased(admin, response, order.remorsePeriodEnd)
     } yield response
 }


### PR DESCRIPTION
Admin showed line items individually, however we want them grouped if
they can be grouped.

https://trello.com/c/hKClUJyN/339-admin-orders-multiple-units-of-one-line-item-doesn-t-stack-together-which-results-in-3-x-duck-items-with-qty-1-each