### PR TITLE
These files should be reverted back to use hostname.

### DIFF
--- a/prov-shit/ansible/roles/base/mesos_master/templates/run_mesos_master.sh
+++ b/prov-shit/ansible/roles/base/mesos_master/templates/run_mesos_master.sh
@@ -2,7 +2,7 @@
 
 export MESOS_WEBUI_DIR=/usr/local/share/mesos/webui
 WORK_DIR=/var/lib/mesos
-IP=0.0.0.0
+IP=`hostname -I | awk '{print $1}'`
 QUORUM={{mesos_quorum}}
 
 mesos-master --hostname=$IP --quorum=$QUORUM --ip=$IP --work_dir=$WORK_DIR --zk={{zookeepers}}/mesos --cluster=fox

--- a/prov-shit/ansible/roles/base/mesos_worker/templates/run_mesos_worker.sh
+++ b/prov-shit/ansible/roles/base/mesos_worker/templates/run_mesos_worker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 WORK_DIR=/var/lib/mesos
-IP=0.0.0.0
+IP=`hostname -I | awk '{print $1}'`
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 export MESOS_EXECUTOR_ENVIRONMENT_VARIABLES="{\"LD_LIBRARY_PATH\": \"$LD_LIBRARY_PATH\"}"
 


### PR DESCRIPTION
It was an accident to have them advertise 0.0.0.0 which only makes sense in appliance.