### PR TITLE
Fix index definition in schemas for scope

### DIFF
--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/CouponCodesSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/CouponCodesSearchView.scala
@@ -12,7 +12,7 @@ final case class CouponCodesSearchView()(implicit ec: EC) extends AvroTransforme
       field("code", StringType).analyzer("upper_cased"),
       field("couponId", IntegerType),
       field("promotionId", IntegerType),
-      field("scope", StringType).analyzer("not_analyzed"),
+      field("scope", StringType).index("not_analyzed"),
       field("totalUsed", IntegerType),
       field("createdAt", DateType).format(dateFormat)
   )

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/ProductsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/ProductsSearchView.scala
@@ -11,7 +11,7 @@ final case class ProductsSearchView()(implicit ec: EC) extends AvroTransformer {
       field("id", IntegerType),
       field("productId", IntegerType),
       field("context", StringType).index("not_analyzed"),
-      field("scope", StringType).analyzer("not_analyzed"),
+      field("scope", StringType).index("not_analyzed"),
       field("title", StringType)
         .analyzer("autocomplete")
         .fields(field("raw", StringType).index("not_analyzed")),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/PromotionsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/PromotionsSearchView.scala
@@ -10,7 +10,7 @@ final case class PromotionsSearchView()(implicit ec: EC) extends AvroTransformer
   def mapping() = esMapping("promotions_search_view").fields(
       field("id", IntegerType),
       field("context", StringType).index("not_analyzed"),
-      field("scope", StringType).analyzer("not_analyzed"),
+      field("scope", StringType).index("not_analyzed"),
       field("applyType", StringType).index("not_analyzed"),
       field("promotionName", StringType).analyzer("autocomplete"),
       field("storefrontName", StringType).analyzer("autocomplete"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/SkuSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/SkuSearchView.scala
@@ -11,7 +11,7 @@ final case class SkuSearchView()(implicit ec: EC) extends AvroTransformer {
       field("id", IntegerType),
       field("skuCode", StringType).analyzer("autocomplete"),
       field("context", StringType).index("not_analyzed"),
-      field("scope", StringType).analyzer("not_analyzed"),
+      field("scope", StringType).index("not_analyzed"),
       field("title", StringType)
         .analyzer("autocomplete")
         .fields(field("raw", StringType).index("not_analyzed")),


### PR DESCRIPTION
Fix

```Failure during processing scopes offset 3: RemoteTransportException[[Night Thrasher][127.0.0.1:9300][indices:admin/create]]; nested: MapperParsingException[Failed to parse mapping [sku_search_view]: analyzer [not_analyzed] not found for field [scope]]; nested: MapperParsingException[analyzer [not_analyzed] not found for field [scope]];```