### PR TITLE
Phoenix leak connection detection

### DIFF
--- a/phoenix-scala/resources/application.conf
+++ b/phoenix-scala/resources/application.conf
@@ -7,8 +7,8 @@ db {
   queueSize = 10000
   driverClassName = "org.postgresql.Driver"
   numThreads=20
-  maxPoolSize=20
   maxConnections=20
+  leakDetectionThreshold=60000
 
 
   host    = "localhost"


### PR DESCRIPTION
The problem - https://foxcommerce.slack.com/archives/phoenix/p1478867519000067

From HikariCP [documentation](https://github.com/brettwooldridge/HikariCP):

> `leakDetectionThreshold`
> This property controls the amount of time that a connection can be out of the pool before a message is logged indicating a possible connection leak. **A value of 0 means leak detection is disabled**. Lowest acceptable value for enabling leak detection is 2000 (2 seconds). **Default: 0**

Also, removed `maxPoolSize` option, because there is no such parameter in Slick config:
http://slick.lightbend.com/doc/3.1.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver):Database