### PR TITLE
Allows shipping methods to be filtered by tag.

### DIFF
--- a/phoenix-scala/app/services/CartValidator.scala
+++ b/phoenix-scala/app/services/CartValidator.scala
@@ -20,7 +20,7 @@ trait CartValidation {
 case class CartValidatorResponse(alerts: Option[Failures] = None,
                                  warnings: Option[Failures] = None) {}
 
-case class CartValidator(cart: Cart)(implicit ec: EC) extends CartValidation {
+case class CartValidator(cart: Cart)(implicit ec: EC, db: DB) extends CartValidation {
 
   def validate(isCheckout: Boolean = false,
                fatalWarnings: Boolean = false): DbResultT[CartValidatorResponse] = {
@@ -59,7 +59,8 @@ case class CartValidator(cart: Cart)(implicit ec: EC) extends CartValidation {
     }
   }
 
-  private def validShipMethod(response: CartValidatorResponse): DBIO[CartValidatorResponse] =
+  private def validShipMethod(response: CartValidatorResponse)(
+      implicit db: DB): DBIO[CartValidatorResponse] =
     (for {
       osm ← OrderShippingMethods.findByOrderRef(cart.refNum)
       sm  ← osm.shippingMethod

--- a/phoenix-scala/app/services/account/AccountManager.scala
+++ b/phoenix-scala/app/services/account/AccountManager.scala
@@ -77,7 +77,7 @@ object AccountManager {
       accessMethod ← * <~ AccountAccessMethods
                       .findOneByAccountIdAndName(account.id, "login")
                       .mustFindOr(AccessMethodNotFound("login"))
-      _ <- * <~ Users.update(user, user.copy(isMigrated = false))
+      _ ← * <~ Users.update(user, user.copy(isMigrated = false))
       _ ← * <~ UserPasswordResets.update(remind,
                                          remind.copy(state = UserPasswordReset.PasswordRestored,
                                                      activatedAt = Instant.now.some))


### PR DESCRIPTION
For example, here is a free shipping method condition for giftcards

    {
        "comparison": "and",
        "conditions": [
                {
                    "rootObject": "LineItems",
                    "field": "countTag-GIFTCARD",
                    "operator" : "greaterThan",
                    "valInt": 0
                },
                {
                    "rootObject": "LineItems",
                    "field": "countWithoutTag-GIFTCARD",
                    "operator" : "equals",
                    "valInt": 0
                }
        ],
        "statements": []
    }

If you setup a free shipping method with that condition it will only show up
if you have 1 or more giftcards in the cart.

To make sure you don't have other shipping methods show up you can set a negative
condition on the tag. For example, here is another condition for a non-free shipping method.

    {
        "comparison": "and",
        "conditions": [
            {
                "rootObject": "LineItems",
                "field": "countWithoutTag-GIFTCARD",
                "operator": "greaterThan",
                "valInt": 0
            },
            {
                "field": "regionName",
                "operator": "notInArray",
                "rootObject": "ShippingAddress",
                "valString": "Connecticut, Delaware, Florida, Illinois, Indiana, Maine, Maryland, Massachusetts, Michigan, North Carolina, New Hampshire, New Jersey, New York, Ohio, Pennsylvania, Rhode Island, Virginia, Vermont, West Virginia"
            }
        ],
        "statements": []
    }

Which shows up if you have anything else in the cart that isn't a gift card.