### PR TITLE
Always include the line item reference number in the order payload

### DIFF
--- a/phoenix-scala/app/responses/cord/base/CordResponseLineItems.scala
+++ b/phoenix-scala/app/responses/cord/base/CordResponseLineItems.scala
@@ -11,7 +11,7 @@ import utils.aliases._
 import utils.db._
 
 case class CordResponseLineItem(imagePath: String,
-                                referenceNumber: String,
+                                referenceNumbers: Seq[String],
                                 name: Option[String],
                                 sku: String,
                                 price: Int,
@@ -56,7 +56,7 @@ object CordResponseLineItems {
       db: DB): DbResultT[Seq[CordResponseLineItem]] =
     for {
       li     ← * <~ LineItemManager.getOrderLineItems(cordRef)
-      result ← * <~ li.map(data ⇒ createResponse(data, 1))
+      result ← * <~ li.map(data ⇒ createResponse(data, Seq(data.lineItemReferenceNumber), 1))
     } yield result
 
   def cordLineItemsGrouped(lineItems: Seq[LineItemProductData[_]],
@@ -94,7 +94,8 @@ object CordResponseLineItems {
       db: DB): DbResultT[Seq[CordResponseLineItem]] =
     for {
       lineItems ← * <~ LineItemManager.getCartLineItems(cordRef)
-      result    ← * <~ lineItems.map(data ⇒ createResponse(data, 1))
+      result ← * <~ lineItems.map(data ⇒
+                    createResponse(data, Seq(data.lineItemReferenceNumber), 1))
     } yield result
 
   private val NOT_A_REF = "not_a_ref"
@@ -123,22 +124,14 @@ object CordResponseLineItems {
       implicit ec: EC,
       db: DB): CordResponseLineItem = {
 
-    val data = lineItemData.head
+    val data             = lineItemData.head
+    val referenceNumbers = lineItemData.map(_.lineItemReferenceNumber)
 
-    //only show reference number for line items that have adjustments.
-    //This is because the adjustment list references the line item by the
-    //reference number. In the future it would be better if each line item
-    //simply had a list of adjustments instead of the list sitting outside
-    //the line item.
-    val referenceNumber =
-      if (adjMap.contains(data.lineItemReferenceNumber))
-        data.lineItemReferenceNumber
-      else ""
-
-    createResponse(data.withLineItemReferenceNumber(referenceNumber), lineItemData.length)
+    createResponse(data, referenceNumbers, lineItemData.length)
   }
 
   private def createResponse(data: LineItemProductData[_],
+                             referenceNumbers: Seq[String],
                              quantity: Int)(implicit ec: EC, db: DB): CordResponseLineItem = {
     require(quantity > 0)
 
@@ -150,7 +143,7 @@ object CordResponseLineItems {
 
     CordResponseLineItem(imagePath = image,
                          sku = data.sku.code,
-                         referenceNumber = data.lineItemReferenceNumber,
+                         referenceNumbers = Seq(data.lineItemReferenceNumber),
                          state = data.lineItemState,
                          name = title,
                          price = price,


### PR DESCRIPTION
We've added the ability for the gift card consumer to update a line item, so always include the primary key(s) with each line item.