### PR TITLE
Short term fix for handling shipment_updated activity from MWH

### DIFF
--- a/green-river/src/main/scala/consumer/elastic/ElasticSearchProcessor.scala
+++ b/green-river/src/main/scala/consumer/elastic/ElasticSearchProcessor.scala
@@ -81,9 +81,12 @@ class ElasticSearchProcessor(
   private val idFields = List("id")
 
   private def getDocumentId(keyJson: String, dataJson: String): Option[BigInt] = {
-    getIntKey(keyJson) match {
-      case None   ⇒ getIntKey(dataJson)
-      case someId ⇒ someId
+    if (keyJson.isEmpty) getIntKey(dataJson)
+    else {
+      getIntKey(keyJson) match {
+        case None   ⇒ getIntKey(dataJson)
+        case someId ⇒ someId
+      }
     }
   }
 

--- a/middlewarehouse/services/activity_logger.go
+++ b/middlewarehouse/services/activity_logger.go
@@ -92,7 +92,7 @@ func newRecord(activity activities.ISiteActivity) (*record, error) {
 		Activity_type: activity.Type(),
 		Data:          activity.Data(),
 		Created_at:    activity.CreatedAt(),
-		Context:       "",
+        Context:       "{\"userId\":0,\"userType\":\"service\", \"transactionId\":\"mwh\"}",
 	}, nil
 }
 


### PR DESCRIPTION
1. Let green river skip bad shipment_updated activities. This is fine since those
activities aren't processed anyway.
2. MWH makes a dummy context for activities.