### PR TITLE
New shared trait for automatic payload validation

### DIFF
--- a/phoenix-scala/app/models/cord/lineitems/OrderLineItem.scala
+++ b/phoenix-scala/app/models/cord/lineitems/OrderLineItem.scala
@@ -1,9 +1,9 @@
 package models.cord.lineitems
 
-import cats.data.Xor
+import cats.data.{ValidatedNel, Xor}
 import cats.implicits._
 import com.pellucid.sealerate
-import failures.Failures
+import failures.{Failure, Failures}
 import models.cord.lineitems.{OrderLineItem ⇒ OLI}
 import models.inventory.{Sku, Skus}
 import models.objects._
@@ -12,6 +12,7 @@ import org.json4s.Formats
 import shapeless._
 import slick.ast.BaseTypedType
 import slick.jdbc.JdbcType
+import utils.Validation._
 import utils._
 import utils.aliases._
 import utils.db.ExPostgresDriver.api._

--- a/phoenix-scala/app/models/cord/lineitems/package.scala
+++ b/phoenix-scala/app/models/cord/lineitems/package.scala
@@ -1,11 +1,26 @@
 package models.cord
 
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.implicits._
+import failures.Failure
+import models.payment.giftcard.GiftCard.giftCardCodeRegex
 import payloads.AddressPayloads.CreateAddressPayload
+import utils.ValidatedPayload
+import utils.Validation._
 
 package object lineitems {
 
   case class LineItemAttributes(giftCard: Option[GiftCardLineItemAttributes] = None,
                                 subscription: Option[CreateAddressPayload] = None)
+      extends ValidatedPayload[LineItemAttributes] {
+
+    override def validate: ValidatedNel[Failure, LineItemAttributes] = {
+      val giftCardOk     = giftCard.fold(ok)(_.validate.map(_ ⇒ Unit))
+      val subscriptionOk = subscription.fold(ok)(_.validate.map(_ ⇒ Unit))
+
+      (giftCardOk |@| subscriptionOk).map { case _ ⇒ this }
+    }
+  }
 
   /*
    * GC line item attrs receive `code` when all of the following fulfill:
@@ -19,5 +34,21 @@ package object lineitems {
                                         recipientEmail: String,
                                         message: String,
                                         code: Option[String] = None)
+      extends ValidatedPayload[GiftCardLineItemAttributes] {
+
+    override def validate: Validated[NonEmptyList[Failure], GiftCardLineItemAttributes] = {
+      val senderNameOk     = notEmpty(senderName, "sender name")
+      val recipientNameOk  = notEmpty(recipientName, "recipient name")
+      val messageOk        = notEmpty(message, "message")
+      val recipientEmailOk = emailish(recipientEmail, "recipient email")
+      val codeOk = code.fold(ok) { gcCode ⇒
+        validExpr(gcCode.matches(giftCardCodeRegex.regex), "code must be a gift card code")
+      }
+
+      (senderNameOk |@| recipientNameOk |@| messageOk |@| recipientEmailOk |@| codeOk).map {
+        case _ ⇒ this
+      }
+    }
+  }
 
 }

--- a/phoenix-scala/app/routes/admin/GiftCardRoutes.scala
+++ b/phoenix-scala/app/routes/admin/GiftCardRoutes.scala
@@ -1,6 +1,8 @@
 package routes.admin
 
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport._
 import models.account.User
 import models.payment.giftcard.GiftCard.giftCardCodeRegex
@@ -15,7 +17,7 @@ import utils.http.Http._
 
 object GiftCardRoutes {
 
-  def routes(implicit ec: EC, db: DB, auth: AuthData[User]) = {
+  def routes(implicit ec: EC, db: DB, auth: AuthData[User]): Route = {
 
     activityContext(auth.model) { implicit ac ⇒
       path("customer-gift-cards") {

--- a/phoenix-scala/app/utils/ValidatedPayload.scala
+++ b/phoenix-scala/app/utils/ValidatedPayload.scala
@@ -1,0 +1,21 @@
+package utils
+
+import cats.data.Validated._
+import failures.Failures
+
+case class FoxValidationException(failures: Failures) extends Exception
+
+/*
+ * Super-fast mechanism for payload validation. If payload is invalid, we should not even proceed to services.
+ * Throwing an exception:
+ * 1. does not require wrapping payload type into `Validated`
+ * 2. happens before any DB transaction is initiated, so it's pretty safe
+ * 2. protects you from forgetting to call `.validate`. We don't have exceptions to payload validation after all!
+ */
+trait ValidatedPayload[A] extends Validation[A] { self: A ⇒
+
+  validate match {
+    case Valid(_)          ⇒ Unit
+    case Invalid(failures) ⇒ throw FoxValidationException(failures)
+  }
+}

--- a/phoenix-scala/app/utils/Validation.scala
+++ b/phoenix-scala/app/utils/Validation.scala
@@ -2,14 +2,14 @@ package utils
 
 import java.time.LocalDateTime
 
+import scala.util.matching.Regex
+
 import cats.data.Validated.{Invalid, Valid, invalidNel, valid}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import com.wix.accord
 import com.wix.accord.RuleViolation
 import com.wix.accord.combinators._
 import failures.{Failure, GeneralFailure}
-
-import scala.util.matching.Regex
 
 trait Validation[M] {
   def validate: ValidatedNel[Failure, M]
@@ -43,6 +43,9 @@ object Validation {
       notEmpty(s, constraint)
     }
   }
+
+  def emailish(maybeEmail: String, fieldName: String): ValidatedNel[Failure, Unit] =
+    validExpr(maybeEmail.contains('@'), s"$fieldName must be an email")
 
   def notExpired(expYear: Int, expMonth: Int, message: String): ValidatedNel[Failure, Unit] = {
     val today = LocalDateTime.now()

--- a/phoenix-scala/app/utils/http/CustomHandlers.scala
+++ b/phoenix-scala/app/utils/http/CustomHandlers.scala
@@ -5,7 +5,7 @@ import scala.util.control.NonFatal
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{Directives, ExceptionHandler, RejectionHandler}
+import akka.http.scaladsl.server._
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 
@@ -29,6 +29,9 @@ object CustomHandlers {
     RejectionHandler
       .newBuilder()
       .handle {
+        case _ @MalformedRequestContentRejection(_, FoxValidationException(failures)) ⇒
+          complete(Http.renderFailure(failures))
+
         case rejection if defaultRejectionHandler(immutable.Seq(rejection)).isDefined ⇒
           mapResponseEntity { entity ⇒
             entity.withContentType(ContentTypes.`application/json`).transformDataBytes {


### PR DESCRIPTION
(plus validation for line item attrs)

All payloads should extend `ValidatedPayload` trait and define their `validate` method. If payload doesn't pass validation, exception is thrown immediately. This has several consequences:
1. We never enter service end don't initiate DB transaction, rejection happens in routes.

2. It's impossible to forget to call `_ ← * <~ payload.validate` and end up with invalid payload, because exception will willingly blow up in your face.

3. If we switch to this approach, `DbResultT` type definition can get rid of tail on `Failures` in favor of single `Failure`. Validation is the only reason we have `NonEmptyList[Failure]`  despite we always return only one `Failure` from service.