### PR TITLE
Return back sql truncate optimization

### DIFF
--- a/phoenix-scala/sql/R__db_test_support_functions.sql
+++ b/phoenix-scala/sql/R__db_test_support_functions.sql
@@ -1,0 +1,16 @@
+create or replace function filter_empty_tables(text[]) returns text[] as $$
+declare
+  tables text[];
+  t text;
+  v boolean;
+begin
+  foreach t in array $1 loop
+    execute format('select true from %s limit 1', t) into v;
+    if v is true then
+        tables := array_append(tables, t);
+    end if;
+  end loop;
+
+  return tables;
+end;
+$$ language plpgsql;


### PR DESCRIPTION
Removed at FoxComm/highlander#526 
Added here https://github.com/FoxComm/phoenix-scala/pull/517 with discussion of it

NEW thing: 
- Filter empty tables at psql function and execute query via preparedStatement