### PR TITLE
Start consumers before seeder

### DIFF
--- a/prov-shit/ansible/vagrant_appliance.yml
+++ b/prov-shit/ansible/vagrant_appliance.yml
@@ -7,7 +7,7 @@
     cert_path: test/fox
     ashes_server_name: local.foxcommerce.com
     storefront_server_name: local.foxcommerce.com
-    storefront_host: firebrand.service.consul
+    storefront_host: storefront.service.consul
     docker_db_host: 172.17.0.1
     install_public_keys: true
     install_private_keys: true


### PR DESCRIPTION
Consumers should be started before seeder to consume added data, e.g. create stock-items