### PR TITLE
Don't use default tcp buf values.

### DIFF
--- a/prov-shit/ansible/roles/base/openvpn/templates/server.conf
+++ b/prov-shit/ansible/roles/base/openvpn/templates/server.conf
@@ -29,3 +29,6 @@ persist-tun
 status /var/log/openvpn-status.log
 log-append  /var/log/openvpn.log
 verb 3
+
+sndbuf 0
+rcvbuf 0


### PR DESCRIPTION
Setting the sndbuf and rcvbuf to 0 forces openvpn to use kernel defaults