### PR TITLE
Wait before Elasticsearch index drop

### DIFF
--- a/green-river/src/main/scala/consumer/elastic/ElasticSearchProcessor.scala
+++ b/green-river/src/main/scala/consumer/elastic/ElasticSearchProcessor.scala
@@ -102,7 +102,6 @@ class ElasticSearchProcessor(
   private def removeIndex() {
     try {
       Console.out.println(s"""Deleting index "$indexName"...""")
-      client.wait(10)
       client.execute(deleteIndex(indexName)).await
     } catch {
       case e: RemoteTransportException ⇒


### PR DESCRIPTION
Trying to avoid this kind of errors:
https://buildkite.com/foxcommerce/duncan-is-hungry/builds/102#acb5b466-9207-4cea-84e5-7df1bdad4601/42-258

I feel like Elasticsearch is not dropping indexes right away, just adds an operation to a queue

And yeah yeah, I know the imperative code itself is awful, we gotta rewrite it someday