### PR TITLE
Fix gift card capture and store credit

### DIFF
--- a/phoenix-scala/app/failures/GiftCardFailures.scala
+++ b/phoenix-scala/app/failures/GiftCardFailures.scala
@@ -18,24 +18,29 @@ object GiftCardFailures {
 
   case class GiftCardPaymentAlreadyAdded(refNum: String, code: String) extends Failure {
     override def description =
-      s"giftCard with code=$code already added as payment method to order with refNum=$refNum"
+      s"Gift Card with code=$code already added as payment method to order with refNum=$refNum"
   }
 
   case class GiftCardPaymentNotFound(refNum: String, code: String) extends Failure {
     override def description =
-      s"giftCard with code=$code is not added as payment method to order with refNum=$refNum"
+      s"Gift Card with code=$code is not added as payment method to order with refNum=$refNum"
+  }
+
+  case class GiftCardAuthAdjustmentNotFound(orderPaymentId: Int) extends Failure {
+    override def description =
+      s"Cannot capture a Gift Card using order payment $orderPaymentId because no adjustment in auth"
   }
 
   case class GiftCardNotEnoughBalance(gc: GiftCard, requestedAmount: Int) extends Failure {
     override def description =
-      s"giftCard with code=${gc.code} has availableBalance=${gc.availableBalance} less than requestedAmount=$requestedAmount"
+      s"Gift Card with code=${gc.code} has availableBalance=${gc.availableBalance} less than requestedAmount=$requestedAmount"
   }
 
   case class GiftCardIsInactive(gc: GiftCard) extends Failure {
-    override def description = s"giftCard with id=${gc.id} is inactive"
+    override def description = s"Gift Card with id=${gc.id} is inactive"
   }
 
   case object CreditCardMustHaveAddress extends Failure {
-    override def description = "cannot create creditCard without an address"
+    override def description = "cannot create Credit Card without an address"
   }
 }

--- a/phoenix-scala/app/failures/StoreCreditFailures.scala
+++ b/phoenix-scala/app/failures/StoreCreditFailures.scala
@@ -16,4 +16,9 @@ object StoreCreditFailures {
     override def description =
       s"customer with id=$id has storeCredit=$has less than requestedAmount=$want"
   }
+
+  case class StoreCreditAuthAdjustmentNotFound(orderPaymentId: Int) extends Failure {
+    override def description =
+      s"Cannot capture a Store Credit using order payment $orderPaymentId because no adjustment in auth"
+  }
 }

--- a/phoenix-scala/app/models/payment/giftcard/GiftCard.scala
+++ b/phoenix-scala/app/models/payment/giftcard/GiftCard.scala
@@ -265,25 +265,31 @@ object GiftCards
 
   import GiftCard._
 
-  def auth(giftCard: GiftCard, orderPaymentId: Option[Int], debit: Int = 0, credit: Int = 0)(
+  def auth(giftCard: GiftCard, orderPaymentId: Int, debit: Int = 0)(
       implicit ec: EC): DbResultT[GiftCardAdjustment] =
-    adjust(giftCard, orderPaymentId, debit = debit, credit = credit, state = Adj.Auth)
+    adjust(giftCard, orderPaymentId.some, debit = debit, state = Adj.Auth)
 
   def authOrderPayment(
       giftCard: GiftCard,
       pmt: OrderPayment,
       maxPaymentAmount: Option[Int] = None)(implicit ec: EC): DbResultT[GiftCardAdjustment] =
-    auth(giftCard = giftCard,
-         orderPaymentId = pmt.id.some,
-         debit = pmt.getAmount(maxPaymentAmount))
+    auth(giftCard = giftCard, orderPaymentId = pmt.id, debit = pmt.getAmount(maxPaymentAmount))
 
   def captureOrderPayment(giftCard: GiftCard, pmt: OrderPayment, maxAmount: Option[Int] = None)(
       implicit ec: EC): DbResultT[GiftCardAdjustment] =
-    capture(giftCard, pmt.id.some, debit = pmt.getAmount(maxAmount))
+    capture(giftCard, pmt.id, debit = pmt.getAmount(maxAmount))
 
-  def capture(giftCard: GiftCard, orderPaymentId: Option[Int], debit: Int, credit: Int = 0)(
+  def capture(giftCard: GiftCard, orderPaymentId: Int, debit: Int)(
       implicit ec: EC): DbResultT[GiftCardAdjustment] =
-    adjust(giftCard, orderPaymentId, debit = debit, credit = credit, state = Adj.Capture)
+    for {
+      auth ← * <~ GiftCardAdjustments
+              .authorizedOrderPayment(orderPaymentId)
+              .mustFindOneOr(GiftCardAuthAdjustmentNotFound(orderPaymentId))
+      _ ← * <~ (
+             require(debit <= auth.debit)
+         )
+      cap ← * <~ GiftCardAdjustments.update(auth, auth.copy(debit = debit, state = Adj.Capture))
+    } yield cap
 
   def cancelByCsr(giftCard: GiftCard, storeAdmin: User)(
       implicit ec: EC): DbResultT[GiftCardAdjustment] = {
@@ -321,11 +327,12 @@ object GiftCards
   def findActive(): QuerySeq =
     filter(_.state === (GiftCard.Active: GiftCard.State))
 
-  private def adjust(giftCard: GiftCard,
-                     orderPaymentId: Option[Int],
-                     debit: Int = 0,
-                     credit: Int = 0,
-                     state: GiftCardAdjustment.State = Adj.Auth)(
+  //Public because tests use it to validate DB constraints
+  def adjust(giftCard: GiftCard,
+             orderPaymentId: Option[Int],
+             debit: Int = 0,
+             credit: Int = 0,
+             state: GiftCardAdjustment.State = Adj.Auth)(
       implicit ec: EC): DbResultT[GiftCardAdjustment] = {
     val balance = giftCard.availableBalance - debit + credit
     val adjustment = Adj(giftCardId = giftCard.id,

--- a/phoenix-scala/app/models/payment/giftcard/GiftCardAdjustment.scala
+++ b/phoenix-scala/app/models/payment/giftcard/GiftCardAdjustment.scala
@@ -105,6 +105,9 @@ object GiftCardAdjustments
   def authorizedOrderPayments(orderPaymentIds: Seq[Int]): QuerySeq =
     filter(adj ⇒ adj.orderPaymentId.inSet(orderPaymentIds) && adj.state === (Auth: State))
 
+  def authorizedOrderPayment(orderPaymentId: Int): QuerySeq =
+    filter(adj ⇒ adj.orderPaymentId === orderPaymentId && adj.state === (Auth: State))
+
   object scope {
 
     implicit class GCAQuerySeqAdditions(query: QuerySeq) {

--- a/phoenix-scala/app/models/payment/storecredit/StoreCreditAdjustment.scala
+++ b/phoenix-scala/app/models/payment/storecredit/StoreCreditAdjustment.scala
@@ -90,6 +90,9 @@ object StoreCreditAdjustments
   def authorizedOrderPayments(orderPaymentIds: Seq[Int]): QuerySeq =
     filter(adj ⇒ adj.orderPaymentId.inSet(orderPaymentIds) && adj.state === (Auth: State))
 
+  def authorizedOrderPayment(orderPaymentId: Int): QuerySeq =
+    filter(adj ⇒ adj.orderPaymentId === orderPaymentId && adj.state === (Auth: State))
+
   object scope {
 
     implicit class SCAQuerySeqAdditions(query: QuerySeq) {

--- a/phoenix-scala/app/services/Capture.scala
+++ b/phoenix-scala/app/services/Capture.scala
@@ -110,8 +110,8 @@ case class Capture(payload: CapturePayloads.Capture)(implicit ec: EC, db: DB, ap
                                                            scPayments,
                                                            order.currency)
       internalCaptureTotal = total - externalCaptureTotal
-      _ ← * <~ externalCapture(externalCaptureTotal, order)
       _ ← * <~ internalCapture(internalCaptureTotal, order, customer, gcPayments, scPayments)
+      _ ← * <~ externalCapture(externalCaptureTotal, order)
 
       resp = CaptureResponse(order = order.refNum,
                              captured = total,

--- a/phoenix-scala/app/utils/seeds/GiftCardSeeds.scala
+++ b/phoenix-scala/app/utils/seeds/GiftCardSeeds.scala
@@ -23,8 +23,6 @@ trait GiftCardSeeds {
       _      ← * <~ GiftCardSubtypes.createAll(giftCardSubTypes)
       origin ← * <~ GiftCardManuals.create(GiftCardManual(adminId = 1, reasonId = 1))
       gc1    ← * <~ GiftCards.create(giftCard.copy(originId = origin.id))
-      _      ← * <~ GiftCards.capture(gc1, debit = 1000, orderPaymentId = None)
-
       gc2 ← * <~ GiftCards.create(
                build(payload(balance = 10000, reasonId = 1), originId = origin.id))
       _ ← * <~ Notes.createAll(giftCardNotes.map(_.copy(referenceId = gc1.id)))

--- a/phoenix-scala/app/utils/seeds/generators/OrderGenerator.scala
+++ b/phoenix-scala/app/utils/seeds/generators/OrderGenerator.scala
@@ -111,7 +111,8 @@ trait OrderGenerator extends ShipmentSeeds {
               StoreCredit(originId = origin.id, accountId = accountId, originalBalance = totals))
       op ← * <~ OrderPayments.create(
               OrderPayment.build(sc).copy(cordRef = cart.refNum, amount = totals.some))
-      _             ← * <~ StoreCredits.capture(sc, op.id.some, totals)
+      _             ← * <~ StoreCredits.auth(sc, op.id, totals)
+      _             ← * <~ StoreCredits.capture(sc, op.id, totals)
       addr          ← * <~ getDefaultAddress(accountId)
       shipMethodIds ← * <~ ShippingMethods.map(_.id).result
       shipMethod    ← * <~ getShipMethod(1 + Random.nextInt(shipMethodIds.length))

--- a/phoenix-scala/sql/V4.072__fix_gift_card_and_store_credit_balance_adjustment.sql
+++ b/phoenix-scala/sql/V4.072__fix_gift_card_and_store_credit_balance_adjustment.sql
@@ -1,0 +1,87 @@
+create or replace function update_gift_card_current_balance() returns trigger as $$
+declare
+    adjustment integer default 0;
+    new_available_balance integer default 0;
+    refund integer default 0;
+begin
+    if new.debit > 0 then
+        adjustment := new.debit;
+    elsif new.credit > 0 then
+        adjustment := -new.credit;
+    end if;
+
+    if new.state = 'auth' then
+            update gift_cards
+                set available_balance = available_balance - adjustment
+                where id = new.gift_card_id
+                returning available_balance into new_available_balance;
+        new.available_balance = new_available_balance;
+    elsif new.state = 'canceled' then
+            update gift_cards
+                set available_balance = available_balance + adjustment
+                where id = new.gift_card_id
+                returning available_balance into new_available_balance;
+        new.available_balance = new_available_balance;
+    elsif new.state = 'capture' then
+        if tg_op = 'INSERT' then
+            refund := -adjustment;
+        elsif old.state = 'auth'  then
+            refund := old.debit - new.debit;
+        end if;
+        update gift_cards
+            set current_balance = current_balance - adjustment,
+            available_balance = available_balance + refund
+            where id = new.gift_card_id;
+    elsif new.state = 'cancellationCapture' then
+            update gift_cards
+                set current_balance = current_balance + adjustment,
+                available_balance = available_balance + adjustment
+                where id = new.gift_card_id;
+    else
+        raise exception 'Failed to update gift card balance with id %, the state % is unknown', new.gift_card_id, new.state;
+    end if;
+    return new;
+end;
+$$ language plpgsql;
+
+create or replace function update_store_credit_current_balance() returns trigger as $$
+declare
+    adjustment integer default 0;
+    new_available_balance integer default 0;
+    refund integer default 0;
+begin
+    adjustment := new.debit;
+
+    if new.state = 'auth' then
+        update store_credits
+            set available_balance = available_balance - adjustment
+            where id = new.store_credit_id
+            returning available_balance into new_available_balance;
+        new.available_balance = new_available_balance;
+    elsif new.state = 'canceled' then
+        update store_credits
+            set available_balance = available_balance + adjustment
+            where id = new.store_credit_id
+            returning available_balance into new_available_balance;
+        new.available_balance = new_available_balance;
+    elsif new.state = 'capture' then
+        if tg_op = 'INSERT' then
+            refund := -adjustment;
+        elsif old.state = 'auth'  then
+            refund := old.debit - new.debit;
+        end if;
+        update store_credits
+            set current_balance = current_balance - adjustment,
+            available_balance = available_balance + refund
+            where id = new.store_credit_id;
+    elsif new.state = 'cancellationCapture'  then
+        update store_credits
+            set current_balance = current_balance + adjustment,
+            available_balance = available_balance + adjustment
+            where id = new.store_credit_id;
+    else
+        raise exception 'Failed to update store credit balance with id %, the state % is unknown', new.store_credit_id, new.state;
+    end if;
+    return new;
+end;
+$$ language plpgsql;

--- a/phoenix-scala/test/integration/GiftCardIntegrationTest.scala
+++ b/phoenix-scala/test/integration/GiftCardIntegrationTest.scala
@@ -341,6 +341,6 @@ class GiftCardIntegrationTest
     val (cart, customer, payment) = (setup.cart, setup.customer, setup.orderPayments.head)
 
     // TODO: replace with checkout?
-    val adjustment1 = GiftCards.auth(giftCard1, Some(payment.id), 10).gimme
+    val adjustment1 = GiftCards.auth(giftCard1, payment.id, 10).gimme
   }
 }

--- a/phoenix-scala/test/integration/StoreCreditIntegrationTest.scala
+++ b/phoenix-scala/test/integration/StoreCreditIntegrationTest.scala
@@ -242,7 +242,7 @@ class StoreCreditIntegrationTest
                                                      paymentMethodId = storeCredit.id,
                                                      paymentMethodType = PaymentMethod.StoreCredit,
                                                      amount = Some(storeCredit.availableBalance)))
-      adjustment ← * <~ StoreCredits.auth(storeCredit, Some(payment.id), 10)
+      adjustment ← * <~ StoreCredits.auth(storeCredit, payment.id, 10)
     } yield (storeCredit, adjustment, scSecond, payment, scSubType)).gimme
   }
 }

--- a/phoenix-scala/test/integration/models/GiftCardIntegrationTest.scala
+++ b/phoenix-scala/test/integration/models/GiftCardIntegrationTest.scala
@@ -21,7 +21,8 @@ class GiftCardIntegrationTest
     }
 
     "updates availableBalance if auth adjustment is created + cancel handling" in new Fixture {
-      val adjustment = GiftCards.capture(giftCard, Some(orderPayments.head.id), 10).gimme
+      val auth       = GiftCards.auth(giftCard, orderPayments.head.id, 10).gimme
+      val adjustment = GiftCards.capture(giftCard, orderPayments.head.id, 10).gimme
 
       val updatedGiftCard = GiftCards.refresh(giftCard).gimme
       updatedGiftCard.availableBalance must === (giftCard.originalBalance - 10)
@@ -29,19 +30,6 @@ class GiftCardIntegrationTest
       GiftCardAdjustments.cancel(adjustment.id).gimme
       val canceledGiftCard = GiftCards.refresh(giftCard).gimme
       canceledGiftCard.availableBalance must === (giftCard.originalBalance)
-    }
-
-    "updates availableBalance and currentBalance if capture adjustment is created + cancel handling" in new Fixture {
-      val adjustment = GiftCards.capture(giftCard, Some(orderPayments.head.id), 0, 10).gimme
-
-      val updatedGiftCard = GiftCards.refresh(giftCard).gimme
-      updatedGiftCard.availableBalance must === (giftCard.originalBalance + 10)
-      updatedGiftCard.currentBalance must === (giftCard.originalBalance + 10)
-
-      GiftCardAdjustments.cancel(adjustment.id).gimme
-      val canceledGiftCard = GiftCards.refresh(giftCard).gimme
-      canceledGiftCard.availableBalance must === (giftCard.originalBalance)
-      canceledGiftCard.currentBalance must === (giftCard.originalBalance)
     }
   }
 

--- a/phoenix-scala/test/integration/models/StoreCreditIntegrationTest.scala
+++ b/phoenix-scala/test/integration/models/StoreCreditIntegrationTest.scala
@@ -20,7 +20,7 @@ class StoreCreditIntegrationTest
     }
 
     "updates availableBalance if auth adjustment is created + cancel handling" in new Fixture {
-      val adjustment = StoreCredits.auth(storeCredit, Some(payment.id), 1000).gimme
+      val adjustment = StoreCredits.auth(storeCredit, payment.id, 1000).gimme
 
       val updatedStoreCredit = StoreCredits.findOneById(storeCredit.id).run().futureValue.value
       updatedStoreCredit.availableBalance must === (storeCredit.availableBalance - 1000)
@@ -31,16 +31,14 @@ class StoreCreditIntegrationTest
     }
 
     "updates availableBalance and currentBalance if capture adjustment is created + cancel handling" in new Fixture {
-      val adjustment = StoreCredits.capture(storeCredit, Some(payment.id), 1000).gimme
+      val auth = StoreCredits.auth(storeCredit, payment.id, 1000).gimme
 
       val updatedStoreCredit = StoreCredits.findOneById(storeCredit.id).run().futureValue.value
       updatedStoreCredit.availableBalance must === (storeCredit.availableBalance - 1000)
-      updatedStoreCredit.currentBalance must === (storeCredit.currentBalance - 1000)
 
-      StoreCreditAdjustments.cancel(adjustment.id).run().futureValue
+      StoreCreditAdjustments.cancel(auth.id).run().futureValue
       val canceledStoreCredit = StoreCredits.findOneById(storeCredit.id).run().futureValue.value
       canceledStoreCredit.availableBalance must === (storeCredit.availableBalance)
-      canceledStoreCredit.currentBalance must === (storeCredit.currentBalance)
     }
   }
 

--- a/phoenix-scala/test/integration/services/CartValidatorTest.scala
+++ b/phoenix-scala/test/integration/services/CartValidatorTest.scala
@@ -114,7 +114,7 @@ class CartValidatorTest extends IntegrationTestBase with TestObjectContext with 
         result1.alerts mustBe 'empty
         result1.warnings.value.toList must contain(InsufficientFunds(cart.refNum))
         // Approves authrorized funds
-        GiftCards.auth(giftCard, orderPayment.id.some, grandTotal, 0).gimme
+        GiftCards.auth(giftCard, orderPayment.id, grandTotal).gimme
         val result2 = CartValidator(refresh(cart)).validate(isCheckout = true).gimme
         result2.alerts mustBe 'empty
         result2.warnings.value.toList mustNot contain(InsufficientFunds(cart.refNum))
@@ -132,7 +132,7 @@ class CartValidatorTest extends IntegrationTestBase with TestObjectContext with 
         result1.alerts mustBe 'empty
         result1.warnings.value.toList must contain(InsufficientFunds(cart.refNum))
         // Approves authrorized funds
-        StoreCredits.auth(storeCredit, orderPayment.id.some, grandTotal).gimme
+        StoreCredits.auth(storeCredit, orderPayment.id, grandTotal).gimme
         val result2 = CartValidator(refresh(cart)).validate(isCheckout = true).gimme
         result2.alerts mustBe 'empty
         result2.warnings.value.toList mustNot contain(InsufficientFunds(cart.refNum))


### PR DESCRIPTION
1. To capture gift card you must auth first.
2. capture changes state of auth intead of creating new adjustment
3. To partial capture a gift card requires re-auth like stripe.
4. You cancel auth now, a capture requires refund or manual adjustment.