### PR TITLE
Return `createdAt` value for credit card in cart responses.

### DIFF
--- a/phoenix-scala/app/models/location/Address.scala
+++ b/phoenix-scala/app/models/location/Address.scala
@@ -65,13 +65,13 @@ object Address {
 
   def fromCreditCard(cc: CreditCard): Address =
     Address(accountId = 0,
-            regionId = cc.regionId,
-            name = cc.addressName,
-            address1 = cc.address1,
-            address2 = cc.address2,
-            city = cc.city,
-            zip = cc.zip,
-            phoneNumber = cc.phoneNumber)
+            regionId = cc.address.regionId,
+            name = cc.address.name,
+            address1 = cc.address.address1,
+            address2 = cc.address.address2,
+            city = cc.address.city,
+            zip = cc.address.zip,
+            phoneNumber = cc.address.phoneNumber)
 }
 
 class Addresses(tag: Tag) extends FoxTable[Address](tag, "addresses") {

--- a/phoenix-scala/app/responses/AddressResponse.scala
+++ b/phoenix-scala/app/responses/AddressResponse.scala
@@ -51,13 +51,13 @@ object AddressResponse {
   def buildFromCreditCard(cc: CreditCard, region: Region): AddressResponse =
     AddressResponse(id = 0,
                     region = region,
-                    name = cc.name,
-                    address1 = cc.address1,
-                    address2 = cc.address2,
-                    city = cc.city,
-                    zip = cc.zip,
+                    name = cc.address.name,
+                    address1 = cc.address.address1,
+                    address2 = cc.address.address2,
+                    city = cc.address.city,
+                    zip = cc.address.zip,
                     isDefault = None,
-                    phoneNumber = cc.phoneNumber)
+                    phoneNumber = cc.address.phoneNumber)
 
   def buildMulti(records: Seq[(Address, Region)]): Seq[AddressResponse] =
     records.map((build _).tupled)

--- a/phoenix-scala/app/responses/CreditCardsResponse.scala
+++ b/phoenix-scala/app/responses/CreditCardsResponse.scala
@@ -22,7 +22,7 @@ object CreditCardsResponse {
 
   def buildFromCreditCard(cc: CreditCard)(implicit ec: EC, db: DB): DbResultT[Root] =
     for {
-      region ← * <~ Regions.mustFindById400(cc.regionId)
+      region ← * <~ Regions.mustFindById400(cc.address.regionId)
     } yield build(cc, region)
 
   def build(cc: CreditCard, region: Region): Root =

--- a/phoenix-scala/app/responses/CustomerResponse.scala
+++ b/phoenix-scala/app/responses/CustomerResponse.scala
@@ -33,8 +33,7 @@ object CustomerResponse {
             numOrders: Option[Int] = None,
             rank: Option[CustomerRank] = None,
             lastOrderDays: Option[Long] = None,
-            scTotals: Option[Totals] = None
-            ): Root = {
+            scTotals: Option[Totals] = None): Root = {
 
     require(customerData.userId == customer.id)
     require(customerData.accountId == customer.accountId)

--- a/phoenix-scala/app/responses/cord/base/CordResponsePayments.scala
+++ b/phoenix-scala/app/responses/cord/base/CordResponsePayments.scala
@@ -31,7 +31,8 @@ case class CordResponseCreditCardPayment(id: Int,
                                          expYear: Int,
                                          brand: String,
                                          address: AddressResponse,
-                                         `type`: Type = CreditCard)
+                                         `type`: Type = CreditCard,
+                                         createdAt: Instant)
     extends CordResponsePayments
 
 object CordResponseCreditCardPayment {
@@ -50,6 +51,7 @@ object CordResponseCreditCardPayment {
                                       expMonth = creditCard.expMonth,
                                       expYear = creditCard.expYear,
                                       brand = creditCard.brand,
+                                      createdAt = creditCard.createdAt,
                                       address =
                                         AddressResponse.buildFromCreditCard(creditCard, region))
     })

--- a/phoenix-scala/app/services/carts/CartPaymentUpdater.scala
+++ b/phoenix-scala/app/services/carts/CartPaymentUpdater.scala
@@ -126,7 +126,7 @@ object CartPaymentUpdater {
       cc     ← * <~ CreditCards.mustFindById400(id)
       _      ← * <~ cc.mustBelongToAccount(cart.accountId)
       _      ← * <~ cc.mustBeInWallet
-      region ← * <~ Regions.findOneById(cc.regionId).safeGet
+      region ← * <~ Regions.findOneById(cc.address.regionId).safeGet
       _      ← * <~ OrderPayments.filter(_.cordRef === cart.refNum).creditCards.delete
       _ ← * <~ OrderPayments.create(
              OrderPayment.build(cc).copy(cordRef = cart.refNum, amount = None))

--- a/phoenix-scala/app/services/customers/CustomerManager.scala
+++ b/phoenix-scala/app/services/customers/CustomerManager.scala
@@ -63,7 +63,7 @@ object CustomerManager {
                        .mustFindOneOr(NotFoundFailure404(CustomerData, accountId))
       (customerData, shipRegion, billRegion, rank) = customerDatas
       maxOrdersDate ← * <~ Orders.filter(_.accountId === accountId).map(_.placedAt).max.result
-      totals ← * <~ StoreCreditService.fetchTotalsForCustomer(accountId)
+      totals        ← * <~ StoreCreditService.fetchTotalsForCustomer(accountId)
       phoneOverride ← * <~ doOrGood(customer.phoneNumber.isEmpty,
                                     resolvePhoneNumber(accountId),
                                     None)
@@ -73,7 +73,7 @@ object CustomerManager {
             shipRegion,
             billRegion,
             rank = rank,
-            scTotals  = totals,
+            scTotals = totals,
             lastOrderDays = maxOrdersDate.map(DAYS.between(_, Instant.now)))
   }
 

--- a/phoenix-scala/app/utils/apis/FoxStripe.scala
+++ b/phoenix-scala/app/utils/apis/FoxStripe.scala
@@ -98,12 +98,12 @@ class FoxStripe(stripe: StripeWrapper)(implicit ec: EC) extends FoxStripeApi {
     def update(stripeCard: StripeCard): Result[StripeCard] = {
 
       val params = Map[String, Object](
-          "address_line1" → cc.address1,
-          "address_line2" → cc.address2,
+          "address_line1" → cc.address.address1,
+          "address_line2" → cc.address.address2,
           // ("address_state" → cc.region),
-          "address_zip"  → cc.zip,
-          "address_city" → cc.city,
-          "name"         → cc.addressName,
+          "address_zip"  → cc.address.zip,
+          "address_city" → cc.address.city,
+          "name"         → cc.address.name,
           "exp_year"     → cc.expYear.toString,
           "exp_month"    → cc.expMonth.toString
       )

--- a/phoenix-scala/app/utils/seeds/CreditCardSeeds.scala
+++ b/phoenix-scala/app/utils/seeds/CreditCardSeeds.scala
@@ -29,12 +29,12 @@ trait CreditCardSeeds extends CreditCardGenerator {
                expMonth = today.getMonthValue,
                expYear = today.getYear + 2,
                isDefault = true,
-               regionId = 4129,
-               addressName = "Old Jeff",
-               address1 = "95 W. 5th Ave.",
-               address2 = Some("Apt. 437"),
-               city = "San Mateo",
-               zip = "94402",
+               address = BillingAddress(regionId = 4129,
+                                        name = "Old Jeff",
+                                        address1 = "95 W. 5th Ave.",
+                                        address2 = Some("Apt. 437"),
+                                        city = "San Mateo",
+                                        zip = "94402"),
                brand = "Visa")
   }
 
@@ -49,12 +49,12 @@ trait CreditCardSeeds extends CreditCardGenerator {
                expMonth = 4,
                expYear = today.getYear + 4,
                isDefault = false,
-               regionId = 4141,
-               addressName = "West Ave",
-               address1 = "3590 West Avenue",
-               address2 = None,
-               city = "Indianapolis",
-               zip = "46201",
+               address = BillingAddress(regionId = 4141,
+                                        name = "West Ave",
+                                        address1 = "3590 West Avenue",
+                                        address2 = None,
+                                        city = "Indianapolis",
+                                        zip = "46201"),
                brand = "Visa")
   }
 
@@ -67,12 +67,12 @@ trait CreditCardSeeds extends CreditCardGenerator {
                expMonth = 7,
                expYear = today.getYear + 3,
                isDefault = true,
-               regionId = 4164,
-               addressName = "Haymond Rocks",
-               address1 = "3564 Haymond Rocks Road",
-               address2 = None,
-               city = "Grants Pass",
-               zip = "97526",
+               address = BillingAddress(regionId = 4164,
+                                        name = "Haymond Rocks",
+                                        address1 = "3564 Haymond Rocks Road",
+                                        address2 = None,
+                                        city = "Grants Pass",
+                                        zip = "97526"),
                brand = "Visa")
   }
 
@@ -85,12 +85,12 @@ trait CreditCardSeeds extends CreditCardGenerator {
                expMonth = 3,
                expYear = today.getYear + 3,
                isDefault = true,
-               regionId = 551,
-               addressName = "Bright Quay",
-               address1 = "1851 Bright Quay",
-               address2 = None,
-               city = "Tonganoxie",
-               zip = "S0R-9U4",
+               address = BillingAddress(regionId = 551,
+                                        name = "Bright Quay",
+                                        address1 = "1851 Bright Quay",
+                                        address2 = None,
+                                        city = "Tonganoxie",
+                                        zip = "S0R-9U4"),
                brand = "Visa")
   }
 
@@ -103,12 +103,12 @@ trait CreditCardSeeds extends CreditCardGenerator {
                expMonth = 11,
                expYear = today.getYear + 1,
                isDefault = true,
-               regionId = 787,
                brand = "Visa",
-               addressName = "Výchozí",
-               address1 = "Rvačov 829",
-               address2 = None,
-               city = "Rvačov 829",
-               zip = "413 01")
+               address = BillingAddress(regionId = 787,
+                                        name = "Výchozí",
+                                        address1 = "Rvačov 829",
+                                        address2 = None,
+                                        city = "Rvačov 829",
+                                        zip = "413 01"))
   }
 }

--- a/phoenix-scala/app/utils/seeds/generators/CreditCardGenerator.scala
+++ b/phoenix-scala/app/utils/seeds/generators/CreditCardGenerator.scala
@@ -6,7 +6,7 @@ import scala.util.Random
 
 import faker._
 import models.account.User
-import models.payment.creditcard.CreditCard;
+import models.payment.creditcard.{BillingAddress, CreditCard};
 
 trait CreditCardGenerator extends AddressGenerator {
 
@@ -51,12 +51,12 @@ trait CreditCardGenerator extends AddressGenerator {
                expMonth = today.getMonthValue,
                expYear = today.getYear + 2,
                isDefault = true,
-               regionId = 4129,
-               addressName = customer.name.getOrElse(Name.name),
-               address1 = address.address1,
-               address2 = address.address2,
-               city = address.city,
-               zip = address.zip,
+               address = BillingAddress(regionId = 4129,
+                                        name = customer.name.getOrElse(Name.name),
+                                        address1 = address.address1,
+                                        address2 = address.address2,
+                                        city = address.city,
+                                        zip = address.zip),
                brand = "Visa")
   }
 

--- a/phoenix-scala/test/integration/CreditCardsIntegrationTest.scala
+++ b/phoenix-scala/test/integration/CreditCardsIntegrationTest.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import failures.{GeneralFailure, NotFoundFailure400, NotFoundFailure404}
 import models.account._
 import models.location.{Addresses, Region}
-import models.payment.creditcard.{CreditCard, CreditCards}
+import models.payment.creditcard.{BillingAddress, CreditCard, CreditCards}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentMatchers ⇒ m, _}
 import org.scalatest.BeforeAndAfterEach
@@ -84,17 +84,18 @@ class CreditCardsIntegrationTest
                                 gatewayCustomerId = stripeCustomer.getId,
                                 gatewayCardId = stripeCard.getId,
                                 accountId = customer.accountId,
-                                addressName = theAddress.name,
-                                address1 = theAddress.address1,
-                                address2 = theAddress.address2,
-                                city = theAddress.city,
-                                zip = theAddress.zip,
-                                regionId = theAddress.regionId,
+                                address = BillingAddress(name = theAddress.name,
+                                                         address1 = theAddress.address1,
+                                                         address2 = theAddress.address2,
+                                                         city = theAddress.city,
+                                                         zip = theAddress.zip,
+                                                         regionId = theAddress.regionId),
                                 brand = "Mona Visa",
                                 holderName = "Leo",
                                 lastFour = "1234",
                                 expMonth = 1,
-                                expYear = expYear)
+                                expYear = expYear,
+                                createdAt = creditCards.head.createdAt)
 
       creditCards.head must === (expected)
 
@@ -234,24 +235,26 @@ class CreditCardsIntegrationTest
       Mockito.verify(stripeWrapperMock).createCustomer(customerSourceMap(customer))
 
       CreditCards.result.gimme must have size 1
+      val result: CreditCard = CreditCards.result.gimme.head
 
       val expected = CreditCard(id = 1,
                                 gatewayCustomerId = stripeCustomer.getId,
                                 accountId = customer.accountId,
-                                addressName = theAddress.name,
-                                address1 = theAddress.address1,
-                                address2 = theAddress.address2,
-                                city = theAddress.city,
-                                zip = theAddress.zip,
-                                regionId = theAddress.regionId,
+                                address = BillingAddress(name = theAddress.name,
+                                                         address1 = theAddress.address1,
+                                                         address2 = theAddress.address2,
+                                                         city = theAddress.city,
+                                                         zip = theAddress.zip,
+                                                         regionId = theAddress.regionId),
                                 holderName = "Leo",
                                 brand = "Mona Visa",
                                 lastFour = "1234",
                                 expMonth = 1,
                                 expYear = expYear,
-                                gatewayCardId = stripeCard.getId)
+                                gatewayCardId = stripeCard.getId,
+                                createdAt = result.createdAt)
 
-      CreditCards.result.gimme.head must === (expected)
+      result must === (expected)
 
       // With existing Stripe customer
       Mockito.clearInvocations(stripeWrapperMock)

--- a/phoenix-scala/test/integration/CustomerIntegrationTest.scala
+++ b/phoenix-scala/test/integration/CustomerIntegrationTest.scala
@@ -32,7 +32,6 @@ import testutils._
 import testutils.apis.{PhoenixAdminApi, PhoenixPublicApi}
 import testutils.fixtures.BakedFixtures
 import utils.MockedApis
-import utils.aliases.AU
 import utils.aliases.stripe.StripeCard
 import utils.db._
 import utils.seeds.Seeds.Factories
@@ -78,7 +77,7 @@ class CustomerIntegrationTest
     }
 
     "customer info shows valid billingRegion" in new CreditCardFixture {
-      val billRegion = Regions.findOneById(creditCard.regionId).gimme
+      val billRegion = Regions.findOneById(creditCard.address.regionId).gimme
 
       val root = CustomerResponse
         .build(customer, customerData, shippingRegion = region.some, billingRegion = billRegion)
@@ -361,7 +360,7 @@ class CustomerIntegrationTest
 
       val creditCards =
         customersApi(customer.accountId).payments.creditCards.get().as[Seq[CardResponse]]
-      val ccRegion = Regions.findOneById(creditCard.regionId).gimme.value
+      val ccRegion = Regions.findOneById(creditCard.address.regionId).gimme.value
 
       creditCards must have size 1
       creditCards.head must === (CreditCardsResponse.build(creditCard, ccRegion))
@@ -475,7 +474,8 @@ class CustomerIntegrationTest
         val numAddresses = Addresses.length.result.gimme
 
         numAddresses must === (1)
-        (newVersion.zip, newVersion.regionId) must === ((address.zip, address.regionId))
+        (newVersion.address.zip, newVersion.address.regionId) must === (
+            (address.zip, address.regionId))
       }
 
       "creates a new address book entry if a full address was given" in new CreditCardFixture {
@@ -496,8 +496,10 @@ class CustomerIntegrationTest
         val newAddress = addresses.last
 
         addresses must have size 2
-        (newVersion.zip, newVersion.regionId) must === (("54321", address.regionId + 1))
-        (newVersion.zip, newVersion.regionId) must === ((newAddress.zip, newAddress.regionId))
+        (newVersion.address.zip, newVersion.address.regionId) must === (
+            ("54321", address.regionId + 1))
+        (newVersion.address.zip, newVersion.address.regionId) must === (
+            (newAddress.zip, newAddress.regionId))
       }
     }
 

--- a/phoenix-scala/test/unit/models/CreditCardTest.scala
+++ b/phoenix-scala/test/unit/models/CreditCardTest.scala
@@ -45,8 +45,8 @@ class CreditCardTest extends TestBase {
         val zipFailure: NonEmptyList[Failure] = NonEmptyList(
             GeneralFailure(s"zip must fully match regular expression '${Address.zipPatternUs}'"))
 
-        val badZip         = card.copy(zip = "AB+123")
-        val wrongLengthZip = card.copy(zip = "1")
+        val badZip         = card.copy(address = card.address.copy(zip = "AB+123"))
+        val wrongLengthZip = card.copy(address = card.address.copy(zip = "1"))
 
         val cards = Table(
             ("creditCards", "errors"),


### PR DESCRIPTION
This PR just adds `CreditCard.createdAt` field.

But CreditCard becomes class with 23 fields and therefore it cannot be used in slick (scala supports max 22 fields in tuple)
So address related fields were moved to a separate `CreditCardAddress` class.

Fixes https://app.yodiz.com/plan/pages/scrum-board.vz?cid=31946&pid=3&iid=3#/app/bg-15