### PR TITLE
Mapping is not created properly for scoped views

### DIFF
--- a/green-river/src/main/scala/consumer/elastic/ScopeProcessor.scala
+++ b/green-river/src/main/scala/consumer/elastic/ScopeProcessor.scala
@@ -74,6 +74,8 @@ class ScopeProcessor(uri: String,
             case e: RemoteTransportException
                 if e.getCause.isInstanceOf[IndexAlreadyExistsException] ⇒
               Console.out.println(s"Index $scopedIndexName already exists, skip")
+            case other ⇒
+              Console.println(s"Creation of index $scopedIndexName failed with error: $other")
           }
         }
     }

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/CartsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/CartsSearchView.scala
@@ -10,7 +10,7 @@ final case class CartsSearchView()(implicit ec: EC) extends AvroTransformer {
   def mapping() = esMapping("carts_search_view").fields(
       // Cart
       field("id", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("referenceNumber", StringType).analyzer("upper_cased"),
       field("createdAt", DateType) format dateFormat,
       field("updatedAt", DateType) format dateFormat,

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/CouponCodesSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/CouponCodesSearchView.scala
@@ -12,7 +12,7 @@ final case class CouponCodesSearchView()(implicit ec: EC) extends AvroTransforme
       field("code", StringType).analyzer("upper_cased"),
       field("couponId", IntegerType),
       field("promotionId", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("totalUsed", IntegerType),
       field("createdAt", DateType).format(dateFormat)
   )

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/CustomerItemsView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/CustomerItemsView.scala
@@ -9,7 +9,7 @@ import consumer.elastic.mappings.dateFormat
 final case class CustomerItemsView()(implicit ec: EC) extends AvroTransformer {
   def mapping() = esMapping("customer_items_view").fields(
       field("id", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       // Customer
       field("customerId", IntegerType),
       field("customerName", StringType).analyzer("autocomplete"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/CustomersSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/CustomersSearchView.scala
@@ -11,7 +11,7 @@ final case class CustomersSearchView()(implicit ec: EC) extends AvroTransformer 
   def mapping() = esMapping("customers_search_view").fields(
       // Customer
       field("id", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("name", StringType)
         .analyzer("autocomplete")
         .fields(field("raw", StringType).index("not_analyzed")),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/GiftCardTransactionsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/GiftCardTransactionsSearchView.scala
@@ -20,7 +20,7 @@ final case class GiftCardTransactionsSearchView()(implicit ec: EC) extends AvroT
       field("originType", StringType).index("not_analyzed"),
       field("currency", StringType).index("not_analyzed"),
       field("giftCardCreatedAt", DateType).format(dateFormat),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       // Order Payment
       field("orderPayment").nested(
           field("orderReferenceNumber", StringType).analyzer("upper_cased"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/GiftCardsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/GiftCardsSearchView.scala
@@ -17,7 +17,7 @@ final case class GiftCardsSearchView()(implicit ec: EC) extends AvroTransformer 
       field("currentBalance", IntegerType),
       field("availableBalance", IntegerType),
       field("canceledAmount", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("createdAt", DateType).format(dateFormat),
       field("updatedAt", DateType).format(dateFormat)
   )

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/InventorySearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/InventorySearchView.scala
@@ -30,7 +30,7 @@ final case class InventorySearchView()(implicit ec: EC) extends AvroTransformer 
       field("createdAt", DateType).format(dateFormat),
       field("updatedAt", DateType).format(dateFormat),
       field("deletedAt", DateType).format(dateFormat),
-      field("scope", StringType)
+      field("scope", StringType).index("not_analyzed")
   )
 
   override def nestedFields() = List("stock_item", "stock_location")

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/InventoryTransactionSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/InventoryTransactionSearchView.scala
@@ -18,6 +18,6 @@ final case class InventoryTransactionSearchView()(implicit ec: EC) extends AvroT
       field("quantityChange", IntegerType),
       field("afsNew", IntegerType),
       field("createdAt", DateType).format(dateFormat),
-      field("scope", StringType)
+      field("scope", StringType).index("not_analyzed")
   )
 }

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/NotesSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/NotesSearchView.scala
@@ -10,7 +10,7 @@ final case class NotesSearchView()(implicit ec: EC) extends AvroTransformer {
   def mapping() = esMapping("notes_search_view").fields(
       // Note
       field("id", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("referenceId", IntegerType),
       field("referenceType", StringType).index("not_analyzed"),
       field("body", StringType).analyzer("autocomplete"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/OrdersSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/OrdersSearchView.scala
@@ -12,7 +12,7 @@ final case class OrdersSearchView()(implicit ec: EC) extends AvroTransformer {
       field("id", IntegerType),
       field("referenceNumber", StringType).analyzer("upper_cased"),
       field("state", StringType).index("not_analyzed"),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("createdAt", DateType).format(dateFormat),
       field("placedAt", DateType).format(dateFormat),
       field("currency", StringType).index("not_analyzed"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/ProductsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/ProductsSearchView.scala
@@ -11,7 +11,7 @@ final case class ProductsSearchView()(implicit ec: EC) extends AvroTransformer {
       field("id", IntegerType),
       field("productId", IntegerType),
       field("context", StringType).index("not_analyzed"),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("title", StringType)
         .analyzer("autocomplete")
         .fields(field("raw", StringType).index("not_analyzed")),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/PromotionsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/PromotionsSearchView.scala
@@ -10,7 +10,7 @@ final case class PromotionsSearchView()(implicit ec: EC) extends AvroTransformer
   def mapping() = esMapping("promotions_search_view").fields(
       field("id", IntegerType),
       field("context", StringType).index("not_analyzed"),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("applyType", StringType).index("not_analyzed"),
       field("promotionName", StringType).analyzer("autocomplete"),
       field("storefrontName", StringType).analyzer("autocomplete"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/SkuSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/SkuSearchView.scala
@@ -11,7 +11,7 @@ final case class SkuSearchView()(implicit ec: EC) extends AvroTransformer {
       field("id", IntegerType),
       field("skuCode", StringType).analyzer("autocomplete"),
       field("context", StringType).index("not_analyzed"),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("title", StringType)
         .analyzer("autocomplete")
         .fields(field("raw", StringType).index("not_analyzed")),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/StoreAdminsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/StoreAdminsSearchView.scala
@@ -10,7 +10,7 @@ final case class StoreAdminsSearchView()(implicit ec: EC) extends AvroTransforme
   def mapping() = esMapping("store_admins_search_view").fields(
       // Store Admin
       field("id", IntegerType),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("email", StringType).analyzer("autocomplete"),
       field("name", StringType).analyzer("autocomplete"),
       field("phoneNumber", StringType).index("not_analyzed"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/StoreCreditTransactionsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/StoreCreditTransactionsSearchView.scala
@@ -20,7 +20,7 @@ final case class StoreCreditTransactionsSearchView()(implicit ec: EC) extends Av
       field("originType", StringType).index("not_analyzed"),
       field("currency", StringType).index("not_analyzed"),
       field("storeCreditCreatedAt", DateType).format(dateFormat),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       // Order Payment
       field("orderPayment").nested(
           field("orderReferenceNumber", StringType).analyzer("upper_cased"),

--- a/green-river/src/main/scala/consumer/elastic/mappings/admin/StoreCreditsSearchView.scala
+++ b/green-river/src/main/scala/consumer/elastic/mappings/admin/StoreCreditsSearchView.scala
@@ -20,7 +20,7 @@ final case class StoreCreditsSearchView()(implicit ec: EC) extends AvroTransform
       field("canceledAmount", IntegerType),
       field("createdAt", DateType).format(dateFormat),
       field("updatedAt", DateType).format(dateFormat),
-      field("scope", StringType),
+      field("scope", StringType).index("not_analyzed"),
       field("storeAdmin").nested(
           field("email", StringType).analyzer("autocomplete"),
           field("name", StringType).analyzer("autocomplete"),


### PR DESCRIPTION
`scope` fields were defined like plain string fields and not analyzed ones.
I changed all of them to be not analyzed.
Also added handler for unrecognised exceptions on mapping creation. Earlier only exception about existing mapping was handled (damn you, Scala, for not checking all cases sufficiency when guards are used)