### PR TITLE
Removing bottledwater base task from appliance.

### DIFF
--- a/prov-shit/ansible/vagrant_appliance.yml
+++ b/prov-shit/ansible/vagrant_appliance.yml
@@ -23,7 +23,6 @@
     - { role: dev/kafka }
     - { role: dev/elasticsearch }
     - { role: dev/kibana, sudo: true }
-    - { role: base/bottledwater }
     - { role: dev/db }
     - { role: dev/isaac }
     - { role: dev/phoenix }


### PR DESCRIPTION
It is already handled in the basebox.

See here: 
https://github.com/FoxComm/highlander/blob/d8f40b75df75a7446fc340db71c23bba0be94c08/prov-shit/ansible/vagrant_appliance_base.yml#L28

Building it again from the appliance is not required, and just adds duplicative effort and time to `vagrant up`