### PR TITLE
Ashes: Fix JWT skip verify mode & upd readme

### DIFF
--- a/ashes/Makefile
+++ b/ashes/Makefile
@@ -38,6 +38,12 @@ run-staging: setup stop
 run-production: setup stop
 	export NODE_ENV=production; nohup ./node_modules/.bin/gulp server 2>&1 &
 
+hooks:
+	./node_modules/.bin/gulp hooks
+
+dev d:
+	test -f .env && export eval `cat .env` || true && ./node_modules/.bin/gulp dev
+
 build-dev: setup
 	./node_modules/.bin/flow check
 	test -f .env && export eval `cat .env` || true && ON_SERVER=true ./node_modules/.bin/gulp build
@@ -57,4 +63,4 @@ docker-push:
 	docker tag $(DOCKER_TAG) $(DOCKER_REPO)/$(DOCKER_TAG):$(DOCKER_BRANCH)
 	docker push $(DOCKER_REPO)/$(DOCKER_TAG):$(DOCKER_BRANCH)
 
-.PHONY: build test test-cov tag docker docker-push
+.PHONY: hooks dev d build test test-cov tag docker docker-push

--- a/ashes/README.md
+++ b/ashes/README.md
@@ -5,7 +5,7 @@
 * node
 
 5.1.0 or above is required version for Ashes.
-To install this or anothers versions of node you can use [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) node version manager.
+To install this or anothers versions of node you can use [brew](http://brew.sh), [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) node version manager.
 
 If using nvm, run the following to install the version listed in `.nvmrc`. For example, if using node `v5.1.0`, follow these commands:
 
@@ -40,16 +40,25 @@ npm install
 
 ### Get certificate to communicate with Phoenix
 
-You can clone `prov-shit` repository and use `${PROV_SHIT_HOME}/ansible/roles/secret_keys/files/public_key.pem`. It is encrypted by ansible and you'll have to decrypt it.
+You can clone `prov-shit` repository and use `${PROV_SHIT_HOME}/ansible/roles/secret_keys/files/public_key.pem`. It is encrypted by ansible and you'll have to decrypt it. Add it to `.env` file: `export PHOENIX_PUBLIC_KEY=${PATH_TO_KEY}`.
+
+or just add `export DEV_SKIP_JWT_VERIFY=1` to `.env` file for non-production usage.
 
 ### Run the dev server
 
 ```
-PHOENIX_PUBLIC_KEY=${PATH_TO_KEY} npm run dev
+make d
 ```
 
-By default, gulp run tests before starting node-server, but you can define env variable ASHES_NO_TEST_FOR_DEV
-for disable this behaviour.
+By default, gulp run tests before starting node-server, but you can define env variable `ASHES_NO_TEST_FOR_DEV`
+for disable this behaviour. Also, see `ASHES_NO_WATCH_FOR_TEST`:
+
+```
+# disable watching of test files
+export ASHES_NO_WATCH_FOR_TEST=1
+# disable all tests while developing
+export ASHES_NO_TEST_FOR_DEV=1
+```
 
 Also gulp can notify you about tasks completion if env variable ASHES_NOTIFY_ABOUT_TASKS is defined.
 
@@ -59,7 +68,7 @@ or completely override watchify options via `.watchifyrc` file in project root.
 ### Pointing to Phoenix
 
 By default, Ashes looks locally for phoenix and ElasticSearch `http://localhost`. If you want to change
-which phoenix and ES Ashes uses, you can set the `API_URL` environment variable.
+which phoenix and ES Ashes uses, you can set the `API_URL` environment variable `export API_URL=...` to `.env` file.
 
 ```
 export API_URL=http://10.240.0.3
@@ -69,23 +78,20 @@ npm run dev
 ### Stripe.js
 
 In order to Stripe.js to work (used for creating credit cards in Stripe) you need to provide publishable key for stripe (https://stripe.com/docs/stripe.js#setting-publishable-key)
-You can set Stripe key by exporting `STRIPE_PUBLISHABLE_KEY` variable, or setting it in your `.env` file if you're using foreman, or run dev command with it:
+You can set Stripe key by exporting `STRIPE_PUBLISHABLE_KEY` variable, or setting it in your `.env`:
 
   `export STRIPE_PUBLISHABLE_KEY=pk_test_r6t0niqmG9OOZhhaSkacUUU1`
-
-  `STRIPE_PUBLISHABLE_KEY=pk_test_r6t0niqmG9OOZhhaSkacUUU1 npm run dev`
-
 
 ### Git Hooks
 
 If you want to setup some Git hooks, run the following:
 
 ```
-./node_modules/.bin/gulp hooks
+make hooks
 ```
 
 Now, installed hook runs tests and prevents push if they haven't passed.
-If you prefer skip test run on each file change you can define env variable ASHES_NO_WATCH_FOR_TEST.
+If you prefer skip test run on each file change you can define env variable `ASHES_NO_WATCH_FOR_TEST`.
 
 ### Vagrant setup
 

--- a/ashes/server/middleware.js
+++ b/ashes/server/middleware.js
@@ -32,8 +32,6 @@ module.exports = function(app) {
     }
   });
 
-  const publicKey = loadPublicKey(config);
-
   function getToken(ctx) {
     const jwtToken = ctx.cookies.get(config.api.auth.cookieName);
     if (!jwtToken) {
@@ -46,7 +44,7 @@ module.exports = function(app) {
         console.info('DEV_SKIP_JWT_VERIFY is enabled, JWT is not verified');
         token = jwt.decode(jwtToken);
       } else {
-        token = jwt.verify(jwtToken, publicKey, {
+        token = jwt.verify(jwtToken, loadPublicKey(config), {
           issuer: 'FC',
           audience: 'user',
           algorithms: ['RS256', 'RS384', 'RS512']


### PR DESCRIPTION
1. Fix jwt-verify: `make d` is not throw an error anymore if `DEV_SKIP_JWT_VERIFY=1`.
2. Update readme
3. Add `make d` alias for simpler dev-launching