### PR TITLE
add/version info

### DIFF
--- a/ashes/.gitignore
+++ b/ashes/.gitignore
@@ -6,6 +6,7 @@ logs
 pids
 *.pid
 *.seed
+.git-rev
 
 # Directory for precompiled es7 sources
 lib

--- a/ashes/Makefile
+++ b/ashes/Makefile
@@ -41,14 +41,21 @@ run-production: setup stop
 hooks:
 	./node_modules/.bin/gulp hooks
 
-dev d:
+rev:
+	git describe --always | cat > .git-rev
+
+dev d: rev
 	test -f .env && export eval `cat .env` || true && ./node_modules/.bin/gulp dev
+
+prod p:
+	test -f .env && export eval `cat .env` || true && NODE_ENV=production ./node_modules/.bin/gulp build
+	test -f .env && export eval `cat .env` || true && NODE_ENV=production node boot.js
 
 build-dev: setup
 	./node_modules/.bin/flow check
 	test -f .env && export eval `cat .env` || true && ON_SERVER=true ./node_modules/.bin/gulp build
 
-build:
+build: rev
 	$(call header, Building)
 	make setup
 	./node_modules/.bin/flow check
@@ -63,4 +70,4 @@ docker-push:
 	docker tag $(DOCKER_TAG) $(DOCKER_REPO)/$(DOCKER_TAG):$(DOCKER_BRANCH)
 	docker push $(DOCKER_REPO)/$(DOCKER_TAG):$(DOCKER_BRANCH)
 
-.PHONY: hooks dev d build test test-cov tag docker docker-push
+.PHONY: hooks rev dev d prod p build test test-cov tag docker docker-push

--- a/ashes/README.md
+++ b/ashes/README.md
@@ -75,6 +75,12 @@ export API_URL=http://10.240.0.3
 npm run dev
 ```
 
+### Run the production server
+
+```
+make p
+```
+
 ### Stripe.js
 
 In order to Stripe.js to work (used for creating credit cards in Stripe) you need to provide publishable key for stripe (https://stripe.com/docs/stripe.js#setting-publishable-key)

--- a/ashes/src/components/header/usermenu.css
+++ b/ashes/src/components/header/usermenu.css
@@ -6,7 +6,7 @@
   background: #fff;
   border: 1px solid #d9d9d9;
   box-shadow: 0 1px 4px 0 rgba(0,0,0,0.1);
-  min-width: 230px;
+  min-width: 300px;
 
   li {
     white-space: nowrap;
@@ -29,10 +29,16 @@
 }
 
 .copyright {
-  padding: 0 8px;
-  line-height: 4;
+  padding: 10px;
+  line-height: 1.3;
   border-top: 1px solid #D6D6D6;
   font-size: 11px;
   color: rgba(72,72,72,.72);
   cursor: default;
+
+  & > span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/ashes/src/components/header/usermenu.jsx
+++ b/ashes/src/components/header/usermenu.jsx
@@ -56,11 +56,16 @@ export class UserMenu extends Component {
   }
 
   render() {
+    const rev = process.env.GIT_REVISION;
+
     return (
       <ul styleName="usermenu">
         {this.settingsLink}
         <li><a onClick={this.handleLogout}>Log out</a></li>
-        <li styleName="copyright">&copy; FoxCommerce. All rights reserved.</li>
+        <li styleName="copyright">
+          &copy; FoxCommerce. All rights reserved.{' '}
+          <span>Version {rev}</span>
+        </li>
       </ul>
     );
   }

--- a/ashes/tasks/browserify.js
+++ b/ashes/tasks/browserify.js
@@ -34,6 +34,13 @@ const excludeList = [
 
 module.exports = function(gulp, opts, $) {
   let production = (process.env.NODE_ENV === 'production');
+  let rev;
+
+  try {
+    rev = fs.readFileSync(path.resolve(__dirname, '..', '.git-rev'), 'utf8').trim();
+  } catch (e) {
+    rev = 'unknown';
+  }
 
   const plugins = require('../src/postcss').plugins;
   let bundler = null;
@@ -54,6 +61,7 @@ module.exports = function(gulp, opts, $) {
       DEMO_AUTH_TOKEN: process.env.DEMO_AUTH_TOKEN,
       API_URL: process.env.API_URL,
       ON_SERVER: process.env.ON_SERVER,
+      GIT_REVISION: rev
     }));
 
     if (production) {


### PR DESCRIPTION
## What is done:

1. Add `rev` task as a dependency for `build` task. It just place `git describe` output to `.git-rev` file, which is in `.gitignore` now.
2. Show `git describe` in ashes header.

There is a small problem: for now, we use long tags with product name as a prefix. It doesn't fit user menu width. I solve this in such a way:

![66](https://cloud.githubusercontent.com/assets/2929442/21479583/956b71e6-cb66-11e6-80b0-96e73a3a39f7.png)

When we will make multitenancy and short tags, it will automatically transforms to this:

![77](https://cloud.githubusercontent.com/assets/2929442/21479582/956ae032-cb66-11e6-959c-73df11027dcf.png)

## How git describe works:
`perfect-gourmet-16.11.0-456-gb6d04c4`:
 * `perfect-gourmet-16.11.0` – most recent tag
 * `456` – fow far it from current commit
 * `gb6d04c4` – current commit

If the current commit has a tag, it would be just a tag name: `perfect-gourmet-16.11.0`.

See also: [git-describe doc](https://git-scm.com/docs/git-describe).

Task: https://trello.com/c/9XFIF8pk/23-add-version-info-to-ashes-for-customers