### PR TITLE
Prevent indexing document to non-existing index

### DIFF
--- a/green-river/build.sbt
+++ b/green-river/build.sbt
@@ -81,18 +81,19 @@ lazy val greenRiver = (project in file(".")).
         |implicit val scalaCache = ScalaCache(LruMapCache(1))
 
         |val config = MainConfig.loadFromConfig
-        |val connInfo = PhoenixConnectionInfo(config.phoenixUri, config.phoenixUser, config.phoenixPass)
+        |val connInfo = PhoenixConnectionInfo(config.phoenixUri, config.phoenixUser, config.phoenixPass, config
+        |.phoenixOrg)
         |val conn = Phoenix(connInfo)
       """.stripMargin,
     assemblyMergeStrategy in assembly := {
         case PathList("org", "joda", xs @ _*) ⇒  MergeStrategy.last
-        case x ⇒ { 
+        case x ⇒ {
             val old = (assemblyMergeStrategy in assembly).value
             old(x)
         }
     },
     scalafmtConfig := Some(file(".scalafmt")),
-    reformatOnCompileSettings // scalafmt    
+    reformatOnCompileSettings // scalafmt
     //test in assembly := {}
 )
 

--- a/green-river/src/main/scala/consumer/elastic/ScopeProcessor.scala
+++ b/green-river/src/main/scala/consumer/elastic/ScopeProcessor.scala
@@ -55,8 +55,7 @@ class ScopeProcessor(uri: String,
   }
 
   private def createIndex(scope: Scope): Future[Unit] = {
-    var createFutures = Buffer[Future[Unit]]()
-    indexTopics.foreach {
+    val futures: Iterable[Future[Unit]] = indexTopics.map {
       case (indexName, topics) ⇒ {
           val scopedIndexName = s"${indexName}_${scope.path}"
           Console.out.println(s"Creating type mappings for index: ${scopedIndexName}")
@@ -66,7 +65,7 @@ class ScopeProcessor(uri: String,
           }.mapValues(_.mapping()).values.toSeq
 
           // create index with scope in the
-          createFutures += client.execute {
+          client.execute {
             create index scopedIndexName mappings (jsonMappings: _*) analysis (autocompleteAnalyzer, lowerCasedAnalyzer, upperCasedAnalyzer)
           }.map { _ ⇒
             ()
@@ -79,6 +78,6 @@ class ScopeProcessor(uri: String,
           }
         }
     }
-    Future.sequence(createFutures).map(_ ⇒ ())
+    Future.sequence(futures).map(_ ⇒ ())
   }
 }

--- a/green-river/src/main/scala/consumer/package.scala
+++ b/green-river/src/main/scala/consumer/package.scala
@@ -35,3 +35,11 @@ trait MessageProcessor {
 }
 
 final case class PassthroughSource(json: String) extends DocumentSource
+
+/**
+  * Used in processors when they want to indicate this document should be processed
+  * again later by MultiTopicConsumer (re-seek to this offset again)
+  */
+trait TryAgainLater { this: Throwable ⇒ }
+
+case class ErrorTryAgainLater(cause: String) extends Throwable with TryAgainLater

--- a/prov-shit/ansible/roles/base/elasticsearch/templates/elasticsearch.yml
+++ b/prov-shit/ansible/roles/base/elasticsearch/templates/elasticsearch.yml
@@ -100,3 +100,6 @@ threadpool:
 # action.destructive_requires_name: true
 
 script.engine.groovy.inline.aggs: on
+
+# Disable automatic index creation
+action.auto_create_index: false


### PR DESCRIPTION
Disable auto creation index at elastic settings.
And in case we have race condition (try to put document to scope index before it was created) - retry later

By default Elastic creates index & mapping on first try
to index document (basic one, without analyzers, etc)
And this index/mapping cannot be updated later,
this is how elasticsearch works.
See https://www.elastic.co/guide/en/elasticsearch/reference/2.1/docs-index_.html#index-creation
And https://www.elastic.co/guide/en/elasticsearch/reference/2.3/mapping.html#_updating_existing_mappings