### PR TITLE
References was not participated in filtering at checkBuckets

### DIFF
--- a/phoenix-scala/app/models/discount/SearchReference.scala
+++ b/phoenix-scala/app/models/discount/SearchReference.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 import cats.data.Xor
 import models.discount.SearchReference._
 import models.sharedsearch.SharedSearches
+import org.json4s.JsonAST.JObject
 import services.Result
 import utils.ElasticsearchApi.{Buckets, SearchViewReference}
 import utils.aliases._
@@ -12,64 +13,68 @@ import utils.aliases._
 /**
   * Linking mechanism for qualifiers (also used in offers)
   */
-sealed trait SearchReference[K, T] {
+sealed trait SearchReference[T] {
   val searchView: SearchViewReference
   val fieldName: String
+  val pureResult: Result[T]
+  val searchId: Int
 
-  def references(input: DiscountInput): Seq[K]
-  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES, au: AU): Result[T]
+  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES, au: AU): Result[T] = {
+    val refs = references(input)
+    if (refs.isEmpty) return pureResult
+
+    SharedSearches.findOneById(searchId).run().flatMap {
+      case Some(search) ⇒
+        search.rawQuery \ "query" match {
+          case query: JObject ⇒
+            esSearch(query, refs).map(result ⇒ Xor.Right(result))
+          case _ ⇒ pureResult
+        }
+      case _ ⇒ pureResult
+    }
+  }
+
+  protected def references(input: DiscountInput): Seq[String]
+  protected def esSearch(query: Json, refs: Seq[String])(implicit es: ES, au: AU): Future[T]
 }
 
-case class CustomerSearch(customerSearchId: Int) extends SearchReference[Int, Long] {
+trait SearchBuckets extends SearchReference[Buckets] {
+  val pureResult: Result[Buckets] = pureBuckets
+
+  def esSearch(query: Json, refs: Seq[String])(implicit es: ES, au: AU): Future[Buckets] =
+    es.checkBuckets(searchView, query, fieldName, refs)
+}
+
+trait SearchMetrics extends SearchReference[Long] {
+  val pureResult: Result[Long] = pureMetrics
+
+  def esSearch(query: Json, refs: Seq[String])(implicit es: ES, au: AU): Future[Long] =
+    es.checkMetrics(searchView, query, fieldName, refs)
+}
+
+case class CustomerSearch(customerSearchId: Int) extends SearchMetrics {
+  val searchId: Int                   = customerSearchId
   val searchView: SearchViewReference = customersSearchView
   val fieldName: String               = customersSearchField
 
-  def references(input: DiscountInput): Seq[Int] = Seq(input.cart.accountId)
-
-  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES, au: AU): Result[Long] = {
-    SharedSearches.findOneById(customerSearchId).run().flatMap {
-      case Some(search) ⇒
-        es.checkMetrics(searchView, search.rawQuery, fieldName, references(input).map(_.toString))
-          .map(result ⇒ Xor.Right(result))
-      case _ ⇒
-        pureMetrics
-    }
-  }
+  def references(input: DiscountInput): Seq[String] = Seq(input.cart.accountId).map(_.toString)
 }
 
-case class ProductSearch(productSearchId: Int) extends SearchReference[Int, Buckets] {
+case class ProductSearch(productSearchId: Int) extends SearchBuckets {
+  val searchId: Int                   = productSearchId
   val searchView: SearchViewReference = productsSearchView
   val fieldName: String               = productsSearchField
 
-  def references(input: DiscountInput): Seq[Int] =
-    input.lineItems.map(_.productForm.id)
-
-  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES, au: AU): Result[Buckets] = {
-    SharedSearches.findOneById(productSearchId).run().flatMap {
-      case Some(search) ⇒
-        es.checkBuckets(searchView, search.rawQuery, fieldName, references(input).map(_.toString))
-          .map(res ⇒ Xor.Right(res))
-      case _ ⇒
-        pureBuckets
-    }
-  }
+  def references(input: DiscountInput): Seq[String] =
+    input.lineItems.map(_.productForm.id.toString)
 }
 
-case class SkuSearch(skuSearchId: Int) extends SearchReference[String, Buckets] {
+case class SkuSearch(skuSearchId: Int) extends SearchBuckets {
+  val searchId: Int                   = skuSearchId
   val searchView: SearchViewReference = skuSearchView
   val fieldName: String               = skuSearchField
 
   def references(input: DiscountInput): Seq[String] = input.lineItems.map(_.sku.code)
-
-  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES, au: AU): Result[Buckets] = {
-    SharedSearches.findOneById(skuSearchId).run().flatMap {
-      case Some(search) ⇒
-        es.checkBuckets(searchView, search.rawQuery, fieldName, references(input))
-          .map(res ⇒ Xor.Right(res))
-      case _ ⇒
-        pureBuckets
-    }
-  }
 }
 
 object SearchReference {

--- a/phoenix-scala/app/utils/ElasticsearchApi.scala
+++ b/phoenix-scala/app/utils/ElasticsearchApi.scala
@@ -6,15 +6,18 @@ import scala.concurrent.Future
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.{ElasticClient, ElasticsearchClientUri, IndexAndType, RichSearchResponse}
 import com.typesafe.config.Config
+import com.typesafe.scalalogging.LazyLogging
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter
 import org.elasticsearch.search.aggregations.bucket.terms.{StringTerms, Terms}
+import org.json4s.JsonAST.{JArray, JObject, JString}
 import org.json4s.jackson.JsonMethods.{compact, parse, render}
 import utils.ElasticsearchApi._
 import utils.aliases._
 
 // TODO: move to Apis?
-case class ElasticsearchApi(host: String, cluster: String, index: String)(implicit ec: EC) {
+case class ElasticsearchApi(host: String, cluster: String, index: String)(implicit ec: EC)
+    extends LazyLogging {
 
   val aggregationName = "my-unique-aggregation"
   val settings        = Settings.settingsBuilder().put("cluster.name", cluster).build()
@@ -33,7 +36,9 @@ case class ElasticsearchApi(host: String, cluster: String, index: String)(implic
                    fieldName: String,
                    references: Seq[String])(implicit au: AU): Future[Long] = {
 
-    // Extract metrics data from aggregatino results
+    if (references.isEmpty) return Future.successful(0)
+
+    // Extract metrics data from aggregation results
     def getDocCount(resp: RichSearchResponse): Long =
       resp.aggregations.getAsMap.asScala.get(aggregationName) match {
         case Some(agg) ⇒ agg.asInstanceOf[InternalFilter].getDocCount
@@ -55,24 +60,26 @@ case class ElasticsearchApi(host: String, cluster: String, index: String)(implic
     * Injects bucket aggregation by specified field name into prepared query
     */
   def checkBuckets(searchView: SearchViewReference,
-                   query: Json,
+                   esQuery: Json,
                    fieldName: String,
                    references: Seq[String])(implicit au: AU): Future[Buckets] = {
+
+    if (references.isEmpty) return Future.successful(Seq.empty[TheBucket])
 
     def toBucket(bucket: Terms.Bucket): TheBucket =
       TheBucket(key = bucket.getKeyAsString, docCount = bucket.getDocCount)
 
-    // Extract bucket data from aggregration results
+    // Extract bucket data from aggregation results
     def getBuckets(resp: RichSearchResponse): Buckets =
       resp.aggregations.getAsMap.asScala.get(aggregationName) match {
         case Some(agg) ⇒ agg.asInstanceOf[StringTerms].getBuckets.asScala.map(toBucket)
         case _         ⇒ List.empty
       }
 
-    val queryString = compact(render(query))
+    val newQuery    = injectFilterReferences(esQuery, fieldName, references)
+    val queryString = compact(render(newQuery))
 
-    val request =
-      search in getIndexAndType(searchView) rawQuery queryString aggregations (
+    val request = search in getIndexAndType(searchView) rawQuery queryString aggregations (
           aggregation terms aggregationName script s"doc['$fieldName'].value"
       ) size 0
 
@@ -83,8 +90,9 @@ case class ElasticsearchApi(host: String, cluster: String, index: String)(implic
   /**
     * Render compact query for logging
     */
-  private def logQuery(query: String): Unit =
-    Console.out.println(s"Preparing Elasticsearch query: ${compact(render(parse(query)))}")
+  def logQuery(query: String): Unit =
+    logger.debug(s"Preparing Elasticsearch query: ${compact(render(parse(query)))}")
+
 }
 
 object ElasticsearchApi {
@@ -110,4 +118,22 @@ object ElasticsearchApi {
 
   def default()(implicit ec: EC): ElasticsearchApi =
     ElasticsearchApi(host = defaultHost, cluster = defaultCluster, index = defaultIndex)
+
+  protected def injectFilterReferences(query: Json,
+                                       fieldName: String,
+                                       references: Seq[String]): Json = {
+    val refFilter     = JObject("terms" → JObject(fieldName → JArray(references.map(JString).toList)))
+    val currentFilter = query \ "bool" \ "filter"
+    currentFilter match {
+      case singleFilter: JObject ⇒
+        val newFilter = JArray(List(refFilter, singleFilter))
+        query.replace(List("bool", "filter"), newFilter)
+      case JArray(filters) ⇒
+        val newFilter = JArray(List(refFilter) ++ filters)
+        query.replace(List("bool", "filter"), newFilter)
+      case _ ⇒
+        val newQuery = JObject("bool" → JObject("filter" → JArray(List(refFilter))))
+        query.merge(newQuery)
+    }
+  }
 }


### PR DESCRIPTION
We have 2 tradeoffs here:
1) Filter results in scala
2) Inject es filter to rawQuery fetched from postgres

I have choosed second one because for big amount of products
 result can be big, instead of references which almost small list of ids.

Also return pureResult if references is empty without interaction with ES