### PR TITLE
Fix triggered SBT tasks by moving version write to assembly

### DIFF
--- a/phoenix-scala/build.sbt
+++ b/phoenix-scala/build.sbt
@@ -40,7 +40,7 @@ lazy val phoenixScala = (project in file("."))
     (mainClass in Compile) := Some("server.Main"),
     initialCommands in console := fromFile("project/console_init").getLines.mkString("\n"),
     initialCommands in (Compile, consoleQuick) := "",
-    writeVersion <<= sh.toTask(fromFile("project/write_version").getLines.mkString).triggeredBy(compile in Compile),
+    writeVersion <<= sh.toTask(fromFile("project/write_version").getLines.mkString),
     unmanagedResources in Compile += file("version"),
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     javaOptions in Test ++= Seq("-Xmx2G", "-XX:+UseConcMarkSweepGC", "-Dphoenix.env=test"),
@@ -54,7 +54,7 @@ lazy val phoenixScala = (project in file("."))
     logBuffered in IT   := false,
     logBuffered in ET   := false,
     test in assembly := {},
-    addCommandAlias("assembly", "gatling/assembly"),
+    addCommandAlias("assembly", "fullAssembly"),
     addCommandAlias("all", "; clean; gatling/clean; it:compile; gatling/compile; test; gatling/assembly"),
     scalafmtConfig := Some(file(".scalafmt")),
     reformatOnCompileWithItSettings // scalafmt
@@ -85,6 +85,8 @@ lazy val gatling = (project in file("gatling"))
         (assemblyMergeStrategy in assembly).value.apply(x)
     }
   )
+
+fullAssembly <<= Def.task().dependsOn(writeVersion in phoenixScala, assembly in gatling)
 
 // Injected seeds
 seed := (runMain in Compile in phoenixScala).partialInput(" utils.seeds.Seeds seed --seedAdmins --seedDemo 1").evaluated

--- a/phoenix-scala/project/Tasks.scala
+++ b/phoenix-scala/project/Tasks.scala
@@ -5,6 +5,8 @@ object Tasks {
   lazy val scalafmtAll     = taskKey[Unit]("scalafmt all the things")
   lazy val scalafmtTestAll = taskKey[Unit]("scalafmtTest all the things")
 
+  lazy val fullAssembly = taskKey[Unit]("Assembly all the things")
+
   lazy val writeVersion = taskKey[Seq[String]]("Write project version data to version file")
 
   lazy val seed           = inputKey[Unit]("Resets and seeds the database")


### PR DESCRIPTION
All tilde-prefixed tasks have been "broken" (they have been falsely triggering despite no sources were changed) since version file was included into unmanaged sources. This fixes the issue by generating version file only before assembly.