### PR TITLE
Use cordRefNums instead orderRefNums for BULK_STATE_CHANGE order activity

### DIFF
--- a/ashes/src/components/activity-trail/activities/orders/index.jsx
+++ b/ashes/src/components/activity-trail/activities/orders/index.jsx
@@ -43,7 +43,7 @@ const representatives = {
   },
   [types.ORDER_BULK_STATE_CHANGED]: {
     title: data => {
-      const orders = data.orderRefNums.map(ref => {
+      const orders = data.cordRefNums.map(ref => {
         return <CordLink key={ref} cord={{referenceNumber: ref}} />;
       });
 

--- a/ashes/src/components/activity-trail/all.jsx
+++ b/ashes/src/components/activity-trail/all.jsx
@@ -405,7 +405,7 @@ activities = [...activities,
     createdAt,
     data: {
       newState: 'fraudHold',
-      orderRefNums: [
+      cordRefNums: [
         'BR10004',
         'BR10003',
         'BR10001',
@@ -713,7 +713,7 @@ activities = [...activities,
     createdAt,
     data: {
       assignee: user,
-      orderRefNums: [
+      cordRefNums: [
         'BR10001',
         'BR10002',
         'BR10003',
@@ -726,7 +726,7 @@ activities = [...activities,
     createdAt,
     data: {
       assignee: user,
-      orderRefNums: [
+      cordRefNums: [
         'BR10001',
         'BR10002',
         'BR10003',

--- a/ashes/test/fixtures/activity-notifications.js
+++ b/ashes/test/fixtures/activity-notifications.js
@@ -348,7 +348,7 @@ activities = [...activities,
     createdAt,
     data: {
       newState: 'fraudHold',
-      orderRefNums: [
+      cordRefNums: [
         'BR10004',
         'BR10003',
         'BR10001',


### PR DESCRIPTION
https://github.com/FoxComm/highlander/blob/22d10e1ba4269633d222194c6ced36ee98545223/phoenix-scala/app/services/activity/OrderTailored.scala#L23