### PR TITLE
Scoped SharedSearches

### DIFF
--- a/phoenix-scala/app/models/discount/SearchReference.scala
+++ b/phoenix-scala/app/models/discount/SearchReference.scala
@@ -3,23 +3,23 @@ package models.discount
 import scala.concurrent.Future
 
 import cats.data.Xor
+import com.github.tminglei.slickpg.LTree
 import models.discount.SearchReference._
 import models.sharedsearch.SharedSearches
 import org.json4s.JsonAST.JObject
 import services.Result
-import utils.ElasticsearchApi.{Buckets, SearchViewReference}
+import utils.ElasticsearchApi.{Buckets, ScopedSearchView, SearchView}
 import utils.aliases._
 
 /**
   * Linking mechanism for qualifiers (also used in offers)
   */
 sealed trait SearchReference[T] {
-  val searchView: SearchViewReference
   val fieldName: String
   val pureResult: Result[T]
   val searchId: Int
 
-  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES, au: AU): Result[T] = {
+  def query(input: DiscountInput)(implicit db: DB, ec: EC, es: ES): Result[T] = {
     val refs = references(input)
     if (refs.isEmpty) return pureResult
 
@@ -27,62 +27,73 @@ sealed trait SearchReference[T] {
       case Some(search) ⇒
         search.rawQuery \ "query" match {
           case query: JObject ⇒
-            esSearch(query, refs).map(result ⇒ Xor.Right(result))
+            val searchView = searchViewByScope(search.accessScope)
+            esSearch(searchView, query, refs).map(result ⇒ Xor.Right(result))
           case _ ⇒ pureResult
         }
       case _ ⇒ pureResult
     }
   }
 
+  protected val searchViewByScope: (LTree ⇒ SearchView)
   protected def references(input: DiscountInput): Seq[String]
-  protected def esSearch(query: Json, refs: Seq[String])(implicit es: ES, au: AU): Future[T]
+  protected def esSearch(searchView: SearchView, query: Json, refs: Seq[String])(
+      implicit es: ES): Future[T]
 }
 
 trait SearchBuckets extends SearchReference[Buckets] {
   val pureResult: Result[Buckets] = pureBuckets
 
-  def esSearch(query: Json, refs: Seq[String])(implicit es: ES, au: AU): Future[Buckets] =
+  def esSearch(searchView: SearchView, query: Json, refs: Seq[String])(
+      implicit es: ES): Future[Buckets] =
     es.checkBuckets(searchView, query, fieldName, refs)
 }
 
 trait SearchMetrics extends SearchReference[Long] {
   val pureResult: Result[Long] = pureMetrics
 
-  def esSearch(query: Json, refs: Seq[String])(implicit es: ES, au: AU): Future[Long] =
+  def esSearch(searchView: SearchView, query: Json, refs: Seq[String])(
+      implicit es: ES): Future[Long] =
     es.checkMetrics(searchView, query, fieldName, refs)
 }
 
 case class CustomerSearch(customerSearchId: Int) extends SearchMetrics {
-  val searchId: Int                   = customerSearchId
-  val searchView: SearchViewReference = customersSearchView
-  val fieldName: String               = customersSearchField
+  val searchId: Int     = customerSearchId
+  val searchViewByScope = searchView(customersSearchView)
+  val fieldName: String = customersSearchField
 
   def references(input: DiscountInput): Seq[String] = Seq(input.cart.accountId).map(_.toString)
 }
 
 case class ProductSearch(productSearchId: Int) extends SearchBuckets {
-  val searchId: Int                   = productSearchId
-  val searchView: SearchViewReference = productsSearchView
-  val fieldName: String               = productsSearchField
+  val searchId: Int     = productSearchId
+  val searchViewByScope = scopedSearchView(productsSearchView)
+  val fieldName: String = productsSearchField
 
   def references(input: DiscountInput): Seq[String] =
     input.lineItems.map(_.productForm.id.toString)
 }
 
 case class SkuSearch(skuSearchId: Int) extends SearchBuckets {
-  val searchId: Int                   = skuSearchId
-  val searchView: SearchViewReference = skuSearchView
-  val fieldName: String               = skuSearchField
+  val searchId: Int     = skuSearchId
+  val searchViewByScope = scopedSearchView(skuSearchView)
+  val fieldName: String = skuSearchField
 
   def references(input: DiscountInput): Seq[String] = input.lineItems.map(_.sku.code)
 }
 
 object SearchReference {
-  def customersSearchView: SearchViewReference =
-    SearchViewReference("customers_search_view", scoped = false)
-  def productsSearchView: SearchViewReference =
-    SearchViewReference("products_search_view", scoped = true)
-  def skuSearchView: SearchViewReference = SearchViewReference("sku_search_view", scoped = true)
+  val customersSearchView: String = "customers_search_view"
+  val productsSearchView: String  = "products_search_view"
+  val skuSearchView: String       = "sku_search_view"
+
+  def scopedSearchView(view: String): (LTree ⇒ SearchView) = { scope: LTree ⇒
+    ScopedSearchView(view, scope.toString)
+  }
+
+  def searchView(view: String): (LTree ⇒ SearchView) = { _ ⇒
+    SearchView(view)
+  }
 
   def customersSearchField: String = "id"
   def productsSearchField: String  = "productId"

--- a/phoenix-scala/app/services/SharedSearchService.scala
+++ b/phoenix-scala/app/services/SharedSearchService.scala
@@ -34,9 +34,10 @@ object SharedSearchService {
     } yield associates.map(UserResponse.build)
 
   def create(admin: User, payload: SharedSearchPayload)(implicit ec: EC,
-                                                        db: DB): DbResultT[SharedSearch] =
+                                                        db: DB,
+                                                        au: AU): DbResultT[SharedSearch] =
     for {
-      search ← * <~ SharedSearches.create(SharedSearch.byAdmin(admin, payload))
+      search ← * <~ SharedSearches.create(SharedSearch.byAdmin(admin, payload, Scope.current))
       _ ← * <~ SharedSearchAssociations.create(
              SharedSearchAssociation(sharedSearchId = search.id, storeAdminId = admin.accountId))
     } yield search

--- a/phoenix-scala/app/utils/seeds/SharedSearchSeeds.scala
+++ b/phoenix-scala/app/utils/seeds/SharedSearchSeeds.scala
@@ -8,10 +8,11 @@ import models.sharedsearch.{SharedSearch, SharedSearchAssociation, SharedSearchA
 import org.json4s.jackson.JsonMethods._
 import utils.db._
 import slick.driver.PostgresDriver.api._
+import utils.aliases.AU
 
 trait SharedSearchSeeds {
 
-  def createSharedSearches(adminId: Int): DbResultT[SharedSearch] =
+  def createSharedSearches(adminId: Int)(implicit au: AU): DbResultT[SharedSearch] =
     for {
       search        ← * <~ SharedSearches.create(sharedSearch(adminId))
       productSearch ← * <~ SharedSearches.create(archivedProductsSearch(adminId))
@@ -29,14 +30,15 @@ trait SharedSearchSeeds {
          }
     } yield search
 
-  def sharedSearch(adminId: Int) =
+  def sharedSearch(adminId: Int)(implicit au: AU) =
     SharedSearch(title = "All Products",
                  query = parse("[]"),
                  rawQuery = parse("{}"),
                  storeAdminId = adminId,
-                 scope = SharedSearch.ProductsScope)
+                 scope = SharedSearch.ProductsScope,
+                 accessScope = Scope.current)
 
-  def archivedProductsSearch(adminId: Int) =
+  def archivedProductsSearch(adminId: Int)(implicit au: AU) =
     SharedSearch(title = "Archived",
                  query = parse("""[
                                  |    {
@@ -63,9 +65,10 @@ trait SharedSearchSeeds {
                                   |   }""".stripMargin),
                  storeAdminId = adminId,
                  scope = SharedSearch.ProductsScope,
+                 accessScope = Scope.current,
                  isSystem = true)
 
-  def archivedSkusSearch(adminId: Int) =
+  def archivedSkusSearch(adminId: Int)(implicit au: AU) =
     SharedSearch(title = "Archived",
                  query = parse("""[
                       |    {
@@ -92,5 +95,6 @@ trait SharedSearchSeeds {
                          | }""".stripMargin),
                  storeAdminId = adminId,
                  scope = SharedSearch.SkusScope,
+                 accessScope = Scope.current,
                  isSystem = true)
 }

--- a/phoenix-scala/sql/V4.081__shared_searches_add_scope.sql
+++ b/phoenix-scala/sql/V4.081__shared_searches_add_scope.sql
@@ -1,0 +1,9 @@
+alter table shared_searches add column access_scope exts.ltree;
+
+update shared_searches set access_scope = exts.text2ltree(get_scope_path((
+        select scope_id from organizations
+            inner join account_organizations as aco on (organizations.id = aco.organization_id)
+          where aco.account_id = shared_searches.store_admin_id
+      ))::text);
+
+alter table shared_searches alter column access_scope set not null;

--- a/phoenix-scala/test/integration/SharedSearchIntegrationTest.scala
+++ b/phoenix-scala/test/integration/SharedSearchIntegrationTest.scala
@@ -273,42 +273,50 @@ class SharedSearchIntegrationTest
                                      query = dummyJVal,
                                      rawQuery = dummyJVal,
                                      scope = CustomersScope,
-                                     storeAdminId = storeAdmin.accountId)
+                                     storeAdminId = storeAdmin.accountId,
+                                     accessScope = scope)
     val orderScope = SharedSearch(title = "Manual Hold",
                                   query = dummyJVal,
                                   rawQuery = dummyJVal,
                                   scope = OrdersScope,
-                                  storeAdminId = storeAdmin.accountId)
+                                  storeAdminId = storeAdmin.accountId,
+                                  accessScope = scope)
     val storeAdminScope = SharedSearch(title = "Some Store Admin",
                                        query = dummyJVal,
                                        rawQuery = dummyJVal,
                                        scope = StoreAdminsScope,
-                                       storeAdminId = storeAdmin.accountId)
+                                       storeAdminId = storeAdmin.accountId,
+                                       accessScope = scope)
     val giftCardScope = SharedSearch(title = "Some Gift Card",
                                      query = dummyJVal,
                                      rawQuery = dummyJVal,
                                      scope = GiftCardsScope,
-                                     storeAdminId = storeAdmin.accountId)
+                                     storeAdminId = storeAdmin.accountId,
+                                     accessScope = scope)
     val productScope = SharedSearch(title = "Some Product",
                                     query = dummyJVal,
                                     rawQuery = dummyJVal,
                                     scope = ProductsScope,
-                                    storeAdminId = storeAdmin.accountId)
+                                    storeAdminId = storeAdmin.accountId,
+                                    accessScope = scope)
     val inventoryScope = SharedSearch(title = "Some Inventory",
                                       query = dummyJVal,
                                       rawQuery = dummyJVal,
                                       scope = InventoryScope,
-                                      storeAdminId = storeAdmin.accountId)
+                                      storeAdminId = storeAdmin.accountId,
+                                      accessScope = scope)
     val promotionsScope = SharedSearch(title = "Some Promotions",
                                        query = dummyJVal,
                                        rawQuery = dummyJVal,
                                        scope = PromotionsScope,
-                                       storeAdminId = storeAdmin.accountId)
+                                       storeAdminId = storeAdmin.accountId,
+                                       accessScope = scope)
     val couponsScope = SharedSearch(title = "Some Coupons",
                                     query = dummyJVal,
                                     rawQuery = dummyJVal,
                                     scope = CouponsScope,
-                                    storeAdminId = storeAdmin.accountId)
+                                    storeAdminId = storeAdmin.accountId,
+                                    accessScope = scope)
 
     val (customersSearch,
          ordersSearch,
@@ -371,7 +379,8 @@ class SharedSearchIntegrationTest
                                query = dummyJVal,
                                rawQuery = dummyJVal,
                                scope = CustomersScope,
-                               storeAdminId = secondAdmin.id))
+                               storeAdminId = secondAdmin.id,
+                               accessScope = scope))
       _ ← * <~ SharedSearchAssociations.create(buildAssociation(search, secondAdmin))
     } yield search).gimme
   }
@@ -381,7 +390,8 @@ class SharedSearchIntegrationTest
                                      query = dummyJVal,
                                      rawQuery = dummyJVal,
                                      scope = CustomersScope,
-                                     storeAdminId = storeAdmin.accountId)
+                                     storeAdminId = storeAdmin.accountId,
+                                     accessScope = scope)
 
     val search = SharedSearches.create(customerScope).gimme
   }


### PR DESCRIPTION
SharedSearches requires scope too.
And use own scope while getting index for ElasticSearch.

Previously index was calculated from scope from current user,
and gives us invalid results in case of customers scope is
different from SharedSearch scope (or owner of SharedSearch scope)