### PR TITLE
Remove test-* environments

### DIFF
--- a/prov-shit/terraform/envs/gce_td_test/terraform.tfstate
+++ b/prov-shit/terraform/envs/gce_td_test/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.8.4",
-    "serial": 12,
+    "serial": 13,
     "lineage": "e5174cc9-ad12-4597-9f20-7e9e8e691182",
     "modules": [
         {
@@ -9,32 +9,7 @@
                 "root"
             ],
             "outputs": {},
-            "resources": {
-                "dnsimple_record.frontend-dns-record": {
-                    "type": "dnsimple_record",
-                    "depends_on": [
-                        "module.top-drawer-test"
-                    ],
-                    "primary": {
-                        "id": "8445828",
-                        "attributes": {
-                            "domain": "foxcommerce.com",
-                            "domain_id": "123968",
-                            "hostname": "test-topdrawer.foxcommerce.com",
-                            "id": "8445828",
-                            "name": "test-topdrawer",
-                            "priority": "0",
-                            "ttl": "3600",
-                            "type": "A",
-                            "value": "10.240.0.27"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                }
-            },
+            "resources": {},
             "depends_on": []
         },
         {
@@ -51,165 +26,8 @@
                 "root",
                 "top-drawer-test"
             ],
-            "outputs": {
-                "consul_address": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "10.240.0.3"
-                },
-                "frontend_address": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "10.240.0.27"
-                }
-            },
-            "resources": {
-                "google_compute_instance.tiny-backend": {
-                    "type": "google_compute_instance",
-                    "depends_on": [
-                        "google_compute_instance.tiny-consul"
-                    ],
-                    "primary": {
-                        "id": "top-drawer-test-backend",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "create_timeout": "4",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.device_name": "",
-                            "disk.0.disk": "",
-                            "disk.0.image": "base-backend-161111-203334",
-                            "disk.0.scratch": "false",
-                            "disk.0.size": "100",
-                            "disk.0.type": "pd-ssd",
-                            "id": "top-drawer-test-backend",
-                            "machine_type": "n1-highmem-4",
-                            "metadata.%": "0",
-                            "metadata_fingerprint": "1-7KLxnxNkU=",
-                            "name": "top-drawer-test-backend",
-                            "network.#": "0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "0",
-                            "network_interface.0.address": "10.240.0.28",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "default",
-                            "network_interface.0.subnetwork": "",
-                            "network_interface.0.subnetwork_project": "",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/top-drawer-test-backend",
-                            "service_account.#": "0",
-                            "tags.#": "2",
-                            "tags.1472900357": "no-ip",
-                            "tags.3202401808": "top-drawer-test-backend",
-                            "tags_fingerprint": "USLOKKVgJW0=",
-                            "zone": "us-central1-a"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                },
-                "google_compute_instance.tiny-consul": {
-                    "type": "google_compute_instance",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "top-drawer-test-consul-server",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "create_timeout": "4",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.device_name": "",
-                            "disk.0.disk": "",
-                            "disk.0.image": "base-amigo-161111-195542",
-                            "disk.0.scratch": "false",
-                            "disk.0.size": "20",
-                            "disk.0.type": "pd-ssd",
-                            "id": "top-drawer-test-consul-server",
-                            "machine_type": "n1-standard-1",
-                            "metadata.%": "0",
-                            "metadata_fingerprint": "1-7KLxnxNkU=",
-                            "name": "top-drawer-test-consul-server",
-                            "network.#": "0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "0",
-                            "network_interface.0.address": "10.240.0.3",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "default",
-                            "network_interface.0.subnetwork": "",
-                            "network_interface.0.subnetwork_project": "",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/top-drawer-test-consul-server",
-                            "service_account.#": "1",
-                            "service_account.0.email": "953682058057-compute@developer.gserviceaccount.com",
-                            "service_account.0.scopes.#": "1",
-                            "service_account.0.scopes.1328717722": "https://www.googleapis.com/auth/devstorage.read_write",
-                            "tags.#": "3",
-                            "tags.1472900357": "no-ip",
-                            "tags.3530402578": "top-drawer-test-consul-server",
-                            "tags.501356857": "top-drawer-test",
-                            "tags_fingerprint": "LL6cejBcZpY=",
-                            "zone": "us-central1-a"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                },
-                "google_compute_instance.tiny-frontend": {
-                    "type": "google_compute_instance",
-                    "depends_on": [
-                        "google_compute_instance.tiny-consul"
-                    ],
-                    "primary": {
-                        "id": "top-drawer-test-frontend",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "create_timeout": "4",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.device_name": "",
-                            "disk.0.disk": "",
-                            "disk.0.image": "base-frontend-161111-200508",
-                            "disk.0.scratch": "false",
-                            "disk.0.size": "30",
-                            "disk.0.type": "pd-ssd",
-                            "id": "top-drawer-test-frontend",
-                            "machine_type": "n1-highmem-8",
-                            "metadata.%": "0",
-                            "metadata_fingerprint": "1-7KLxnxNkU=",
-                            "name": "top-drawer-test-frontend",
-                            "network.#": "0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "0",
-                            "network_interface.0.address": "10.240.0.27",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "default",
-                            "network_interface.0.subnetwork": "",
-                            "network_interface.0.subnetwork_project": "",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/top-drawer-test-frontend",
-                            "service_account.#": "0",
-                            "tags.#": "4",
-                            "tags.1472900357": "no-ip",
-                            "tags.1936433573": "https-server",
-                            "tags.4136979037": "top-drawer-test-frontend",
-                            "tags.988335155": "http-server",
-                            "tags_fingerprint": "gUEtO_UfEV8=",
-                            "zone": "us-central1-a"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                }
-            },
+            "outputs": {},
+            "resources": {},
             "depends_on": []
         }
     ]

--- a/prov-shit/terraform/envs/gce_td_test/terraform.tfstate.backup
+++ b/prov-shit/terraform/envs/gce_td_test/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.8.4",
-    "serial": 11,
+    "serial": 12,
     "lineage": "e5174cc9-ad12-4597-9f20-7e9e8e691182",
     "modules": [
         {
@@ -9,7 +9,32 @@
                 "root"
             ],
             "outputs": {},
-            "resources": {},
+            "resources": {
+                "dnsimple_record.frontend-dns-record": {
+                    "type": "dnsimple_record",
+                    "depends_on": [
+                        "module.top-drawer-test"
+                    ],
+                    "primary": {
+                        "id": "8445828",
+                        "attributes": {
+                            "domain": "foxcommerce.com",
+                            "domain_id": "123968",
+                            "hostname": "test-topdrawer.foxcommerce.com",
+                            "id": "8445828",
+                            "name": "test-topdrawer",
+                            "priority": "0",
+                            "ttl": "3600",
+                            "type": "A",
+                            "value": "10.240.0.27"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
             "depends_on": []
         },
         {
@@ -30,15 +55,161 @@
                 "consul_address": {
                     "sensitive": false,
                     "type": "string",
-                    "value": "10.240.0.25"
+                    "value": "10.240.0.3"
                 },
                 "frontend_address": {
                     "sensitive": false,
                     "type": "string",
-                    "value": "10.240.0.34"
+                    "value": "10.240.0.27"
                 }
             },
-            "resources": {},
+            "resources": {
+                "google_compute_instance.tiny-backend": {
+                    "type": "google_compute_instance",
+                    "depends_on": [
+                        "google_compute_instance.tiny-consul"
+                    ],
+                    "primary": {
+                        "id": "top-drawer-test-backend",
+                        "attributes": {
+                            "can_ip_forward": "false",
+                            "create_timeout": "4",
+                            "disk.#": "1",
+                            "disk.0.auto_delete": "true",
+                            "disk.0.device_name": "",
+                            "disk.0.disk": "",
+                            "disk.0.image": "base-backend-161111-203334",
+                            "disk.0.scratch": "false",
+                            "disk.0.size": "100",
+                            "disk.0.type": "pd-ssd",
+                            "id": "top-drawer-test-backend",
+                            "machine_type": "n1-highmem-4",
+                            "metadata.%": "0",
+                            "metadata_fingerprint": "1-7KLxnxNkU=",
+                            "name": "top-drawer-test-backend",
+                            "network.#": "0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "0",
+                            "network_interface.0.address": "10.240.0.28",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "default",
+                            "network_interface.0.subnetwork": "",
+                            "network_interface.0.subnetwork_project": "",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/top-drawer-test-backend",
+                            "service_account.#": "0",
+                            "tags.#": "2",
+                            "tags.1472900357": "no-ip",
+                            "tags.3202401808": "top-drawer-test-backend",
+                            "tags_fingerprint": "USLOKKVgJW0=",
+                            "zone": "us-central1-a"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                },
+                "google_compute_instance.tiny-consul": {
+                    "type": "google_compute_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "top-drawer-test-consul-server",
+                        "attributes": {
+                            "can_ip_forward": "false",
+                            "create_timeout": "4",
+                            "disk.#": "1",
+                            "disk.0.auto_delete": "true",
+                            "disk.0.device_name": "",
+                            "disk.0.disk": "",
+                            "disk.0.image": "base-amigo-161111-195542",
+                            "disk.0.scratch": "false",
+                            "disk.0.size": "20",
+                            "disk.0.type": "pd-ssd",
+                            "id": "top-drawer-test-consul-server",
+                            "machine_type": "n1-standard-1",
+                            "metadata.%": "0",
+                            "metadata_fingerprint": "1-7KLxnxNkU=",
+                            "name": "top-drawer-test-consul-server",
+                            "network.#": "0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "0",
+                            "network_interface.0.address": "10.240.0.3",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "default",
+                            "network_interface.0.subnetwork": "",
+                            "network_interface.0.subnetwork_project": "",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/top-drawer-test-consul-server",
+                            "service_account.#": "1",
+                            "service_account.0.email": "953682058057-compute@developer.gserviceaccount.com",
+                            "service_account.0.scopes.#": "1",
+                            "service_account.0.scopes.1328717722": "https://www.googleapis.com/auth/devstorage.read_write",
+                            "tags.#": "3",
+                            "tags.1472900357": "no-ip",
+                            "tags.3530402578": "top-drawer-test-consul-server",
+                            "tags.501356857": "top-drawer-test",
+                            "tags_fingerprint": "LL6cejBcZpY=",
+                            "zone": "us-central1-a"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                },
+                "google_compute_instance.tiny-frontend": {
+                    "type": "google_compute_instance",
+                    "depends_on": [
+                        "google_compute_instance.tiny-consul"
+                    ],
+                    "primary": {
+                        "id": "top-drawer-test-frontend",
+                        "attributes": {
+                            "can_ip_forward": "false",
+                            "create_timeout": "4",
+                            "disk.#": "1",
+                            "disk.0.auto_delete": "true",
+                            "disk.0.device_name": "",
+                            "disk.0.disk": "",
+                            "disk.0.image": "base-frontend-161111-200508",
+                            "disk.0.scratch": "false",
+                            "disk.0.size": "30",
+                            "disk.0.type": "pd-ssd",
+                            "id": "top-drawer-test-frontend",
+                            "machine_type": "n1-highmem-8",
+                            "metadata.%": "0",
+                            "metadata_fingerprint": "1-7KLxnxNkU=",
+                            "name": "top-drawer-test-frontend",
+                            "network.#": "0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "0",
+                            "network_interface.0.address": "10.240.0.27",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "default",
+                            "network_interface.0.subnetwork": "",
+                            "network_interface.0.subnetwork_project": "",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/top-drawer-test-frontend",
+                            "service_account.#": "0",
+                            "tags.#": "4",
+                            "tags.1472900357": "no-ip",
+                            "tags.1936433573": "https-server",
+                            "tags.4136979037": "top-drawer-test-frontend",
+                            "tags.988335155": "http-server",
+                            "tags_fingerprint": "gUEtO_UfEV8=",
+                            "zone": "us-central1-a"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
             "depends_on": []
         }
     ]

--- a/prov-shit/terraform/envs/gce_tpg_test/terraform.tfstate
+++ b/prov-shit/terraform/envs/gce_tpg_test/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.8.4",
-    "serial": 9,
+    "serial": 10,
     "lineage": "ac72b852-08c7-4088-a2d0-4b6ad3894912",
     "modules": [
         {
@@ -9,32 +9,7 @@
                 "root"
             ],
             "outputs": {},
-            "resources": {
-                "dnsimple_record.frontend-dns-record": {
-                    "type": "dnsimple_record",
-                    "depends_on": [
-                        "module.perfect-gourmet-test"
-                    ],
-                    "primary": {
-                        "id": "8445827",
-                        "attributes": {
-                            "domain": "foxcommerce.com",
-                            "domain_id": "123968",
-                            "hostname": "test-perfectgourmet.foxcommerce.com",
-                            "id": "8445827",
-                            "name": "test-perfectgourmet",
-                            "priority": "0",
-                            "ttl": "3600",
-                            "type": "A",
-                            "value": "10.240.0.30"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                }
-            },
+            "resources": {},
             "depends_on": []
         },
         {
@@ -42,165 +17,8 @@
                 "root",
                 "perfect-gourmet-test"
             ],
-            "outputs": {
-                "consul_address": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "10.240.0.21"
-                },
-                "frontend_address": {
-                    "sensitive": false,
-                    "type": "string",
-                    "value": "10.240.0.30"
-                }
-            },
-            "resources": {
-                "google_compute_instance.tiny-backend": {
-                    "type": "google_compute_instance",
-                    "depends_on": [
-                        "google_compute_instance.tiny-consul"
-                    ],
-                    "primary": {
-                        "id": "perfect-gourmet-test-backend",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "create_timeout": "4",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.device_name": "",
-                            "disk.0.disk": "",
-                            "disk.0.image": "base-backend-161111-203334",
-                            "disk.0.scratch": "false",
-                            "disk.0.size": "100",
-                            "disk.0.type": "pd-ssd",
-                            "id": "perfect-gourmet-test-backend",
-                            "machine_type": "n1-highmem-4",
-                            "metadata.%": "0",
-                            "metadata_fingerprint": "1-7KLxnxNkU=",
-                            "name": "perfect-gourmet-test-backend",
-                            "network.#": "0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "0",
-                            "network_interface.0.address": "10.240.0.31",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "default",
-                            "network_interface.0.subnetwork": "",
-                            "network_interface.0.subnetwork_project": "",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/perfect-gourmet-test-backend",
-                            "service_account.#": "0",
-                            "tags.#": "2",
-                            "tags.1472900357": "no-ip",
-                            "tags.2008301239": "perfect-gourmet-test-backend",
-                            "tags_fingerprint": "6ATG14XTvAc=",
-                            "zone": "us-central1-a"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                },
-                "google_compute_instance.tiny-consul": {
-                    "type": "google_compute_instance",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "perfect-gourmet-test-consul-server",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "create_timeout": "4",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.device_name": "",
-                            "disk.0.disk": "",
-                            "disk.0.image": "base-amigo-161111-195542",
-                            "disk.0.scratch": "false",
-                            "disk.0.size": "20",
-                            "disk.0.type": "pd-ssd",
-                            "id": "perfect-gourmet-test-consul-server",
-                            "machine_type": "n1-standard-1",
-                            "metadata.%": "0",
-                            "metadata_fingerprint": "1-7KLxnxNkU=",
-                            "name": "perfect-gourmet-test-consul-server",
-                            "network.#": "0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "0",
-                            "network_interface.0.address": "10.240.0.21",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "default",
-                            "network_interface.0.subnetwork": "",
-                            "network_interface.0.subnetwork_project": "",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/perfect-gourmet-test-consul-server",
-                            "service_account.#": "1",
-                            "service_account.0.email": "953682058057-compute@developer.gserviceaccount.com",
-                            "service_account.0.scopes.#": "1",
-                            "service_account.0.scopes.1328717722": "https://www.googleapis.com/auth/devstorage.read_write",
-                            "tags.#": "3",
-                            "tags.1472900357": "no-ip",
-                            "tags.165425548": "perfect-gourmet-test",
-                            "tags.1948361954": "perfect-gourmet-test-consul-server",
-                            "tags_fingerprint": "-g9BPabvbRU=",
-                            "zone": "us-central1-a"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                },
-                "google_compute_instance.tiny-frontend": {
-                    "type": "google_compute_instance",
-                    "depends_on": [
-                        "google_compute_instance.tiny-consul"
-                    ],
-                    "primary": {
-                        "id": "perfect-gourmet-test-frontend",
-                        "attributes": {
-                            "can_ip_forward": "false",
-                            "create_timeout": "4",
-                            "disk.#": "1",
-                            "disk.0.auto_delete": "true",
-                            "disk.0.device_name": "",
-                            "disk.0.disk": "",
-                            "disk.0.image": "base-frontend-161111-200508",
-                            "disk.0.scratch": "false",
-                            "disk.0.size": "30",
-                            "disk.0.type": "pd-ssd",
-                            "id": "perfect-gourmet-test-frontend",
-                            "machine_type": "n1-highmem-8",
-                            "metadata.%": "0",
-                            "metadata_fingerprint": "1-7KLxnxNkU=",
-                            "name": "perfect-gourmet-test-frontend",
-                            "network.#": "0",
-                            "network_interface.#": "1",
-                            "network_interface.0.access_config.#": "0",
-                            "network_interface.0.address": "10.240.0.30",
-                            "network_interface.0.name": "nic0",
-                            "network_interface.0.network": "default",
-                            "network_interface.0.subnetwork": "",
-                            "network_interface.0.subnetwork_project": "",
-                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/perfect-gourmet-test-frontend",
-                            "service_account.#": "0",
-                            "tags.#": "4",
-                            "tags.1472900357": "no-ip",
-                            "tags.1936433573": "https-server",
-                            "tags.3203279086": "perfect-gourmet-test-frontend",
-                            "tags.988335155": "http-server",
-                            "tags_fingerprint": "Drtrz4gE348=",
-                            "zone": "us-central1-a"
-                        },
-                        "meta": {
-                            "schema_version": "2"
-                        },
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": ""
-                }
-            },
+            "outputs": {},
+            "resources": {},
             "depends_on": []
         }
     ]

--- a/prov-shit/terraform/envs/gce_tpg_test/terraform.tfstate.backup
+++ b/prov-shit/terraform/envs/gce_tpg_test/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.8.4",
-    "serial": 8,
+    "serial": 9,
     "lineage": "ac72b852-08c7-4088-a2d0-4b6ad3894912",
     "modules": [
         {
@@ -9,7 +9,32 @@
                 "root"
             ],
             "outputs": {},
-            "resources": {},
+            "resources": {
+                "dnsimple_record.frontend-dns-record": {
+                    "type": "dnsimple_record",
+                    "depends_on": [
+                        "module.perfect-gourmet-test"
+                    ],
+                    "primary": {
+                        "id": "8445827",
+                        "attributes": {
+                            "domain": "foxcommerce.com",
+                            "domain_id": "123968",
+                            "hostname": "test-perfectgourmet.foxcommerce.com",
+                            "id": "8445827",
+                            "name": "test-perfectgourmet",
+                            "priority": "0",
+                            "ttl": "3600",
+                            "type": "A",
+                            "value": "10.240.0.30"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
             "depends_on": []
         },
         {
@@ -26,10 +51,156 @@
                 "frontend_address": {
                     "sensitive": false,
                     "type": "string",
-                    "value": "10.240.0.31"
+                    "value": "10.240.0.30"
                 }
             },
-            "resources": {},
+            "resources": {
+                "google_compute_instance.tiny-backend": {
+                    "type": "google_compute_instance",
+                    "depends_on": [
+                        "google_compute_instance.tiny-consul"
+                    ],
+                    "primary": {
+                        "id": "perfect-gourmet-test-backend",
+                        "attributes": {
+                            "can_ip_forward": "false",
+                            "create_timeout": "4",
+                            "disk.#": "1",
+                            "disk.0.auto_delete": "true",
+                            "disk.0.device_name": "",
+                            "disk.0.disk": "",
+                            "disk.0.image": "base-backend-161111-203334",
+                            "disk.0.scratch": "false",
+                            "disk.0.size": "100",
+                            "disk.0.type": "pd-ssd",
+                            "id": "perfect-gourmet-test-backend",
+                            "machine_type": "n1-highmem-4",
+                            "metadata.%": "0",
+                            "metadata_fingerprint": "1-7KLxnxNkU=",
+                            "name": "perfect-gourmet-test-backend",
+                            "network.#": "0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "0",
+                            "network_interface.0.address": "10.240.0.31",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "default",
+                            "network_interface.0.subnetwork": "",
+                            "network_interface.0.subnetwork_project": "",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/perfect-gourmet-test-backend",
+                            "service_account.#": "0",
+                            "tags.#": "2",
+                            "tags.1472900357": "no-ip",
+                            "tags.2008301239": "perfect-gourmet-test-backend",
+                            "tags_fingerprint": "6ATG14XTvAc=",
+                            "zone": "us-central1-a"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                },
+                "google_compute_instance.tiny-consul": {
+                    "type": "google_compute_instance",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "perfect-gourmet-test-consul-server",
+                        "attributes": {
+                            "can_ip_forward": "false",
+                            "create_timeout": "4",
+                            "disk.#": "1",
+                            "disk.0.auto_delete": "true",
+                            "disk.0.device_name": "",
+                            "disk.0.disk": "",
+                            "disk.0.image": "base-amigo-161111-195542",
+                            "disk.0.scratch": "false",
+                            "disk.0.size": "20",
+                            "disk.0.type": "pd-ssd",
+                            "id": "perfect-gourmet-test-consul-server",
+                            "machine_type": "n1-standard-1",
+                            "metadata.%": "0",
+                            "metadata_fingerprint": "1-7KLxnxNkU=",
+                            "name": "perfect-gourmet-test-consul-server",
+                            "network.#": "0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "0",
+                            "network_interface.0.address": "10.240.0.21",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "default",
+                            "network_interface.0.subnetwork": "",
+                            "network_interface.0.subnetwork_project": "",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/perfect-gourmet-test-consul-server",
+                            "service_account.#": "1",
+                            "service_account.0.email": "953682058057-compute@developer.gserviceaccount.com",
+                            "service_account.0.scopes.#": "1",
+                            "service_account.0.scopes.1328717722": "https://www.googleapis.com/auth/devstorage.read_write",
+                            "tags.#": "3",
+                            "tags.1472900357": "no-ip",
+                            "tags.165425548": "perfect-gourmet-test",
+                            "tags.1948361954": "perfect-gourmet-test-consul-server",
+                            "tags_fingerprint": "-g9BPabvbRU=",
+                            "zone": "us-central1-a"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                },
+                "google_compute_instance.tiny-frontend": {
+                    "type": "google_compute_instance",
+                    "depends_on": [
+                        "google_compute_instance.tiny-consul"
+                    ],
+                    "primary": {
+                        "id": "perfect-gourmet-test-frontend",
+                        "attributes": {
+                            "can_ip_forward": "false",
+                            "create_timeout": "4",
+                            "disk.#": "1",
+                            "disk.0.auto_delete": "true",
+                            "disk.0.device_name": "",
+                            "disk.0.disk": "",
+                            "disk.0.image": "base-frontend-161111-200508",
+                            "disk.0.scratch": "false",
+                            "disk.0.size": "30",
+                            "disk.0.type": "pd-ssd",
+                            "id": "perfect-gourmet-test-frontend",
+                            "machine_type": "n1-highmem-8",
+                            "metadata.%": "0",
+                            "metadata_fingerprint": "1-7KLxnxNkU=",
+                            "name": "perfect-gourmet-test-frontend",
+                            "network.#": "0",
+                            "network_interface.#": "1",
+                            "network_interface.0.access_config.#": "0",
+                            "network_interface.0.address": "10.240.0.30",
+                            "network_interface.0.name": "nic0",
+                            "network_interface.0.network": "default",
+                            "network_interface.0.subnetwork": "",
+                            "network_interface.0.subnetwork_project": "",
+                            "self_link": "https://www.googleapis.com/compute/v1/projects/foxcomm-staging/zones/us-central1-a/instances/perfect-gourmet-test-frontend",
+                            "service_account.#": "0",
+                            "tags.#": "4",
+                            "tags.1472900357": "no-ip",
+                            "tags.1936433573": "https-server",
+                            "tags.3203279086": "perfect-gourmet-test-frontend",
+                            "tags.988335155": "http-server",
+                            "tags_fingerprint": "Drtrz4gE348=",
+                            "zone": "us-central1-a"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
             "depends_on": []
         }
     ]


### PR DESCRIPTION
Spinning down `test-topdrawer.foxcommerce.com` and `test-perfectgourmet.foxcommerce.com` because we're not using them actively.

Keeping the Terraform configuration so that we can build it up.