### PR TITLE
Build MWH binaries inside docker

### DIFF
--- a/middlewarehouse/Dockerfile
+++ b/middlewarehouse/Dockerfile
@@ -1,10 +1,14 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates
 
 RUN mkdir -p /middlewarehouse
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o middlewarehouse main.go && \
+    cp middlewarehouse /middlewarehouse && \
+    rm -rf /go
 WORKDIR /middlewarehouse
-COPY middlewarehouse /middlewarehouse
 ADD .env /middlewarehouse
 
 EXPOSE 9292

--- a/middlewarehouse/Makefile
+++ b/middlewarehouse/Makefile
@@ -16,18 +16,16 @@ DOCKER_REPO ?= $(DOCKER_STAGE_REPO)
 DOCKER_IMAGE ?= middlewarehouse
 DOCKER_TAG ?= master
 
-prep:
+prepare:
 	rm $(BUILD_ROOT_PATH) || true
 	mkdir -p $(GOPATH)/src/github.com/FoxComm
 	ln -s $(HIGHLANDER_PATH) $(BUILD_ROOT_PATH) || true
-
-glide: prep
 	cd $(BUILD_PATH) && glide install
-	rm -rf $(BUILD_PATH)/vendor/github.com/FoxComm/highlander
+	rm -rf $(BUILD_PATH)/vendor/github.com/FoxComm/highlander 
 
 build:
 	$(call header, Building)
-	make glide
+	make prepare
 	cd $(BUILD_PATH) && go build -o middlewarehouse main.go
 	cd $(BUILD_PATH) && go build -o consumers/shipments/shipments-consumer consumers/shipments/*.go
 	cd $(BUILD_PATH) && go build -o consumers/stock-items/stock-items-consumer consumers/stock-items/*.go
@@ -38,13 +36,13 @@ build:
 
 docker:
 	$(call header, Dockerizing)
-	docker build -t $(DOCKER_IMAGE) .
-	docker build -t stock-items-consumer consumers/stock-items/
-	docker build -t shipments-consumer consumers/shipments/
-	docker build -t capture-consumer consumers/capture/
-	docker build -t shipstation-consumer consumers/shipstation/
-	docker build -t middlewarehouse-seeder common/db/seeds/
-	docker build -t gift-card-consumer consumers/gift-cards/
+	cd $(BUILD_PATH) && docker build -t $(DOCKER_IMAGE) .
+	cd $(BUILD_PATH) && docker build -t stock-items-consumer -f consumers/stock-items/Dockerfile .
+	cd $(BUILD_PATH) && docker build -t shipments-consumer -f consumers/shipments/Dockerfile .
+	cd $(BUILD_PATH) && docker build -t capture-consumer -f consumers/capture/Dockerfile .
+	cd $(BUILD_PATH) && docker build -t shipstation-consumer -f consumers/shipstation/Dockerfile .
+	cd $(BUILD_PATH) && docker build -t middlewarehouse-seeder -f common/db/seeds/Dockerfile .
+	cd $(BUILD_PATH) && docker build -t gift-card-consumer -f consumers/gift-cards/Dockerfile .
 
 docker-push:
 	$(call header, Registering)
@@ -98,7 +96,8 @@ create-user:
 
 test:
 	$(call header, Testing)
-	make glide
+	make prepare
 	make reset-test
 	# -p 1 serves to run tests sequentially, as it is required for non-isolated database tests
 	cd $(BUILD_PATH) && GOENV=test go test -p 1 `glide nv`
+

--- a/middlewarehouse/common/db/seeds/Dockerfile
+++ b/middlewarehouse/common/db/seeds/Dockerfile
@@ -1,8 +1,12 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN mkdir -p /middlewarehouse
+RUN mkdir -p /middlewarehouse && \
+    touch /middlewarehouse/.env
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o common/db/seeds/seeder common/db/seeds/*.go && \
+    cp common/db/seeds/seeder /middlewarehouse && \
+    rm -rf /go
 WORKDIR /middlewarehouse
-COPY seeder /middlewarehouse
-RUN touch /middlewarehouse/.env
 
 CMD ["/middlewarehouse/seeder"]

--- a/middlewarehouse/consumers/capture/Dockerfile
+++ b/middlewarehouse/consumers/capture/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN apt-get update && apt-get install -y ca-certificates
-RUN apt-get clean
+RUN apk add --no-cache ca-certificates
 
 RUN mkdir -p /capture-consumer
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o consumers/capture/capture-consumer consumers/capture/*.go && \
+    cp consumers/capture/capture-consumer /capture-consumer && \
+    rm -rf /go
 WORKDIR /capture-consumer
-COPY capture-consumer /capture-consumer
 
 CMD /capture-consumer/capture-consumer 2>&1 | tee /logs/capture-consumer.log

--- a/middlewarehouse/consumers/gift-cards/Dockerfile
+++ b/middlewarehouse/consumers/gift-cards/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN apt-get update && apt-get install -y ca-certificates
-RUN apt-get clean
+RUN apk add --no-cache ca-certificates
 
 RUN mkdir -p /gift-card-consumer
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o consumers/gift-cards/gift-card-consumer consumers/gift-cards/*.go && \
+    cp consumers/gift-cards/gift-card-consumer /gift-card-consumer && \
+    rm -rf /go
 WORKDIR /gift-card-consumer
-COPY gift-card-consumer /gift-card-consumer
 
 CMD /gift-card-consumer/gift-card-consumer 2>&1 | tee /logs/gift-card-consumer.log

--- a/middlewarehouse/consumers/shipments/Dockerfile
+++ b/middlewarehouse/consumers/shipments/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN apt-get update && apt-get install -y ca-certificates
-RUN apt-get clean
+RUN apk add --no-cache ca-certificates
 
 RUN mkdir -p /shipments-consumer
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o consumers/shipments/shipments-consumer consumers/shipments/*.go && \
+    cp consumers/shipments/shipments-consumer /shipments-consumer/ && \
+    rm -rf /go
 WORKDIR /shipments-consumer
-COPY shipments-consumer /shipments-consumer
 
 CMD /shipments-consumer/shipments-consumer 2>&1 | tee /log/shipment-consumer.log

--- a/middlewarehouse/consumers/shipstation/Dockerfile
+++ b/middlewarehouse/consumers/shipstation/Dockerfile
@@ -1,7 +1,13 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN apt update
-RUN apt install -y ca-certificates
+RUN apk add --no-cache ca-certificates
 
-ADD shipstation-consumer /
-CMD /shipstation-consumer 2>&1 | tee /logs/shipstation-consumer.log
+RUN mkdir -p /shipstation-consumer
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o consumers/shipstation/shipstation-consumer consumers/shipstation/*.go && \
+    cp consumers/shipstation/shipstation-consumer /shipstation-consumer && \
+    rm -rf /go
+WORKDIR /shipstation-consumer
+
+CMD /shipstation-consumer/shipstation-consumer 2>&1 | tee /logs/shipstation-consumer.log

--- a/middlewarehouse/consumers/stock-items/Dockerfile
+++ b/middlewarehouse/consumers/stock-items/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:16.04
+FROM golang:alpine
 
-RUN apt-get update && apt-get install -y ca-certificates
-RUN apt-get clean
+RUN apk add --no-cache ca-certificates
 
 RUN mkdir -p /stock-items-consumer
+ADD . /go/src/github.com/FoxComm/highlander/middlewarehouse
+WORKDIR /go/src/github.com/FoxComm/highlander/middlewarehouse
+RUN go build -o consumers/stock-items/stock-items-consumer consumers/stock-items/*.go && \
+    cp consumers/stock-items/stock-items-consumer /stock-items-consumer/ && \
+    rm -rf /go
 WORKDIR /stock-items-consumer
-COPY stock-items-consumer /stock-items-consumer
 
 CMD /stock-items-consumer/stock-items-consumer 2>&1 | tee /logs/stock-items-consumer.log


### PR DESCRIPTION
Currently they are built on host, which then causes problems if someone builds them using distro with non debian-like library paths.
PRs behavior is not completely nice, as it first allow `glide` to fetch all deps on host and then copies them to the docker container. However, since we use couple of private repos, I don't know how to make it work painlessly with `glide` fetching deps inside docker container.

The same problem probably will cause `isaac` binary.
I tried at first to change way of it building it too, but it fetches couple of deps from git.
Also, as far as I see it rather does not need to be refreshed that often.