### PR TITLE
added /login redirect in case of error 401 from API

### DIFF
--- a/ashes/src/lib/api.js
+++ b/ashes/src/lib/api.js
@@ -82,7 +82,7 @@ export function request(method, uri, data, options = {}) {
     .then(
       response => response.body,
       err => {
-        if (err.message === 'Unauthorized') {
+        if (err.status == 401) {
           unauthorizedHandler(err.response);
         }
 


### PR DESCRIPTION
Fixed the bug with invalid JWT.
When API call responds 401 error, system now redirects user to /admin/login page.
https://trello.com/c/4sNkIU69
