### PR TITLE
Remove duplicated ObjectUtils.getFullObject

### DIFF
--- a/phoenix-scala/app/models/objects/ObjectHeadLinks.scala
+++ b/phoenix-scala/app/models/objects/ObjectHeadLinks.scala
@@ -2,6 +2,7 @@ package models.objects
 
 import java.time.Instant
 
+import services.objects.ObjectManager
 import utils.aliases._
 import utils.db.ExPostgresDriver.api._
 import utils.db._
@@ -66,10 +67,10 @@ object ObjectHeadLinks {
       } yield linkedObjects.zip(links)
 
     def queryLinkedObject(link: M)(implicit ec: EC, db: DB): DbResultT[FullObject[R]] =
-      ObjectUtils.getFullObject(rightQuery.mustFindById404(link.rightId))
+      ObjectManager.getFullObject(rightQuery.mustFindById404(link.rightId))
 
     def queryLeftLinkedObject(link: M)(implicit ec: EC, db: DB): DbResultT[FullObject[L]] =
-      ObjectUtils.getFullObject(leftQuery.mustFindById404(link.leftId))
+      ObjectManager.getFullObject(leftQuery.mustFindById404(link.leftId))
 
     def syncLinks(left: L, rights: Seq[R])(implicit ec: EC, db: DB): DbResultT[Unit] =
       for {

--- a/phoenix-scala/app/models/objects/ObjectUtils.scala
+++ b/phoenix-scala/app/models/objects/ObjectUtils.scala
@@ -5,15 +5,14 @@ import java.time.Instant
 import cats.data.NonEmptyList
 import cats.implicits._
 import failures.Failure
-import org.json4s.JsonAST.{JField, JNothing, JObject, JString}
+import org.json4s.JsonAST.{JNothing, JObject, JString}
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import utils.IlluminateAlgorithm
 import services.objects.ObjectSchemasManager
+import utils.IlluminateAlgorithm
 import utils.aliases._
 import utils.db._
-import scala.annotation.tailrec
 
 object ObjectUtils {
 
@@ -31,8 +30,8 @@ object ObjectUtils {
 
   /**
     * We compute a SHA-1 hash of the json content and return the first
-    * 10 characters in hex representation of the hash. 
-    * We don't care about the whole hash because it would take up too much space. 
+    * 10 characters in hex representation of the hash.
+    * We don't care about the whole hash because it would take up too much space.
     * Collisions are handled below in the findKey function.
     */
   private def hash(content: Json): String =
@@ -46,8 +45,8 @@ object ObjectUtils {
   /**
     * The key algorithm will compute a hash of the content and then search
     * for a valid key. The search function looks for hash collisions.
-    * If a hash collision is found, an index is appended to the hash and the 
-    * new hash+index key is searched until we find a key with same content or 
+    * If a hash collision is found, an index is appended to the hash and the
+    * new hash+index key is searched until we find a key with same content or
     * we reach the end of the list.
     */
   private[objects] def key(content: Json, alreadyExistingFields: Json): String = {
@@ -263,12 +262,4 @@ object ObjectUtils {
     case head :: tail ⇒ DbResultT.failures(NonEmptyList(head, tail))
     case Nil          ⇒ DbResultT.pure(Unit)
   }
-
-  def getFullObject[T <: ObjectHead[T]](
-      readHead: ⇒ DbResultT[T])(implicit ec: EC, db: DB): DbResultT[FullObject[T]] =
-    for {
-      head   ← * <~ readHead
-      form   ← * <~ ObjectForms.mustFindById404(head.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(head.shadowId)
-    } yield FullObject(head, form, shadow)
 }

--- a/phoenix-scala/app/services/objects/ObjectManager.scala
+++ b/phoenix-scala/app/services/objects/ObjectManager.scala
@@ -1,11 +1,12 @@
 package services.objects
 
-import failures.NotFoundFailure404
+import failures._
 import failures.ObjectFailures._
 import models.objects._
 import payloads.ContextPayloads._
 import responses.ObjectResponses._
 import utils.aliases._
+import utils.db.ExPostgresDriver.api._
 import utils.db._
 
 object ObjectManager {
@@ -59,4 +60,36 @@ object ObjectManager {
       form      ← * <~ ObjectForms.mustFindById404(modelHead.formId)
       shadow    ← * <~ ObjectShadows.mustFindById404(modelHead.shadowId)
     } yield FullObject(modelHead, form, shadow)
+
+  def getFullObjects[T <: ObjectHead[T]](models: Seq[T])(implicit ec: EC,
+                                                         db: DB): DbResultT[Seq[FullObject[T]]] =
+    for {
+      forms   ← * <~ ObjectForms.findAllByIds(models.map(_.formId).toSet).result
+      shadows ← * <~ ObjectShadows.findAllByIds(models.map(_.shadowId).toSet).result
+      result  ← * <~ buildFullObjects(models, forms, shadows)
+    } yield result
+
+  private def buildFullObjects[T <: ObjectHead[T]](models: Seq[T],
+                                                   forms: Seq[ObjectForm],
+                                                   shadows: Seq[ObjectShadow])(implicit ec: EC) = {
+    val formsMap   = forms.groupBy(_.id)
+    val shadowsMap = shadows.groupBy(_.id)
+
+    def getByIdOrFail[M](items: Map[Int, Traversable[M]], id: Int, failure: ⇒ Failures) =
+      items.get(id).flatMap(_.headOption).toXor(failure)
+
+    def buildFullObject(model: T) =
+      for {
+        form ← * <~ getByIdOrFail(formsMap,
+                                  model.formId,
+                                  ObjectForms.notFound404K(model.formId).single)
+
+        shadow ← * <~ getByIdOrFail(shadowsMap,
+                                    model.shadowId,
+                                    ObjectShadows.notFound404K(model.shadowId).single)
+
+      } yield FullObject(model, form, shadow)
+
+    models.map(buildFullObject)
+  }
 }

--- a/phoenix-scala/app/services/taxonomy/TaxonomyManager.scala
+++ b/phoenix-scala/app/services/taxonomy/TaxonomyManager.scala
@@ -58,7 +58,7 @@ object TaxonomyManager {
                                                  oc: OC,
                                                  db: DB): DbResultT[TaxonomyResponse] =
     for {
-      taxonomy ← * <~ ObjectUtils.getFullObject(Taxonomies.mustFindByFormId404(taxonomyFormId))
+      taxonomy ← * <~ ObjectManager.getFullObject(Taxonomies.mustFindByFormId404(taxonomyFormId))
       taxons   ← * <~ TaxonomyTaxonLinks.queryRightByLeftWithLinks(taxonomy.model)
     } yield TaxonomyResponse.build(taxonomy, taxons)
 
@@ -89,7 +89,7 @@ object TaxonomyManager {
     val shadow = ObjectShadow.fromPayload(payload.attributes)
 
     for {
-      taxonomy ← * <~ ObjectUtils.getFullObject(Taxonomies.mustFindByFormId404(taxonomyFormId))
+      taxonomy ← * <~ ObjectManager.getFullObject(Taxonomies.mustFindByFormId404(taxonomyFormId))
       _        ← * <~ failIf(taxonomy.model.archivedAt.isDefined, TaxonomyIsArchived(taxonomyFormId))
       newTaxonomy ← * <~ ObjectUtils.commitUpdate(
                        taxonomy,
@@ -111,7 +111,7 @@ object TaxonomyManager {
                                            oc: OC,
                                            db: DB): DbResultT[SingleTaxonResponse] =
     for {
-      taxonFull ← * <~ ObjectUtils.getFullObject(Taxons.mustFindByFormId404(taxonFormId))
+      taxonFull ← * <~ ObjectManager.getFullObject(Taxons.mustFindByFormId404(taxonFormId))
       response  ← * <~ buildSingleTaxonResponse(taxonFull)
     } yield response
 
@@ -247,7 +247,7 @@ object TaxonomyManager {
     val (form, shadow) = payload.formAndShadow.tupled
 
     for {
-      fullTaxon ← * <~ ObjectUtils.getFullObject(DbResultT.good(taxon))
+      fullTaxon ← * <~ ObjectManager.getFullObject(DbResultT.good(taxon))
       newTaxon ← * <~ ObjectUtils.commitUpdate(
                     fullTaxon,
                     form.attributes,

--- a/phoenix-scala/app/utils/db/SearchTerms.scala
+++ b/phoenix-scala/app/utils/db/SearchTerms.scala
@@ -13,7 +13,7 @@ trait SearchById[M <: FoxModel[M], T <: FoxTable[M]] {
 
   def findOneById(id: M#Id): DBIO[Option[M]]
 
-  protected def notFound404K[K](searchKey: K) =
+  def notFound404K[K](searchKey: K) =
     NotFoundFailure404(
         s"${tableName.tableNameToCamel} with $primarySearchTerm=$searchKey not found")
 

--- a/phoenix-scala/test/integration/PromotionsIntegrationTest.scala
+++ b/phoenix-scala/test/integration/PromotionsIntegrationTest.scala
@@ -16,6 +16,7 @@ import payloads.PromotionPayloads._
 import responses.CouponResponses.CouponResponse
 import responses.PromotionResponses.PromotionResponse
 import responses.cord.CartResponse
+import services.objects.ObjectManager
 import services.promotion.PromotionManager
 import testutils.PayloadHelpers.tv
 import testutils._
@@ -80,7 +81,7 @@ class PromotionsIntegrationTest
   "promotion with 'coupon' apply type should be active on" - {
 
     "creation" in new StoreAdmin_Seed with Promotion_Seed {
-      ObjectUtils
+      ObjectManager
         .getFullObject(DbResultT.pure(promotion))
         .gimme
         .getAttribute("activeFrom") must !==(JNothing)
@@ -88,7 +89,7 @@ class PromotionsIntegrationTest
 
     "updating" in new AutoApplyPromotionSeed {
 
-      var fullPromotion = ObjectUtils.getFullObject(DbResultT.pure(promotion)).gimme
+      var fullPromotion = ObjectManager.getFullObject(DbResultT.pure(promotion)).gimme
       fullPromotion.getAttribute("activeFrom") must === (JNothing)
 
       val attributes: List[(String, JValue)] =
@@ -103,7 +104,7 @@ class PromotionsIntegrationTest
         .gimme
 
       fullPromotion =
-        ObjectUtils.getFullObject(Promotions.mustFindById400(fullPromotion.model.id)).gimme
+        ObjectManager.getFullObject(Promotions.mustFindById400(fullPromotion.model.id)).gimme
       fullPromotion.getAttribute("activeFrom") must !==(JNothing)
     }
   }


### PR DESCRIPTION
- remove duplicated `getFullObject` method (it was in both `ObjectManager` and `ObjectUtils`)
- `getFullObjects` for querying collection of `FullObject[T]` (required for #542)