### PR TITLE
changed location replace url to /admin/login instead of /login

### DIFF
--- a/ashes/src/lib/api.js
+++ b/ashes/src/lib/api.js
@@ -73,7 +73,7 @@ export function request(method, uri, data, options = {}) {
   let error = null;
 
   const unauthorizedHandler = options.unauthorizedHandler ? options.unauthorizedHandler : () => {
-    window.location.href = '/login';
+    window.location.href = '/admin/login';
   };
 
   const abort = _.bind(result.abort, result);


### PR DESCRIPTION
When unauthorized api call is made, system suppose to redirect admin user to /admin/login page.
Instead now it redirects a user to /login. 
For example instead of supposed https://stage.foxcommerce.com/admin/login it redirects to
https://stage.foxcommerce.com/login which not exists.