### PR TITLE
Mesos Consul stops updating consul if agent restarts.

### DIFF
--- a/prov-shit/ansible/roles/dev/consul_agent/tasks/main.yml
+++ b/prov-shit/ansible/roles/dev/consul_agent/tasks/main.yml
@@ -26,3 +26,7 @@
 
 - name: Restart Dnsmasq
   service: name=dnsmasq state=restarted enabled=yes
+
+- name: Restart Mesos Consul Because It Stops Updating Consul
+  service: name=mesos_consul state=restarted enabled=yes
+


### PR DESCRIPTION
This is a quick fix for appliance provisioning.