### PR TITLE
Bad bug, plug the leak in search.

### DIFF
--- a/isaac/src/service/query.cpp
+++ b/isaac/src/service/query.cpp
@@ -140,7 +140,7 @@ namespace isaac
             return r;
         }
 
-        void query_request_handler::check_token(proxygen::HTTPMessage& msg) 
+        void query_request_handler::check_role(proxygen::HTTPMessage& msg)
         {
             const auto token = get_token(msg, _c.token_header);
 
@@ -161,7 +161,7 @@ namespace isaac
             }
         }
 
-        void query_request_handler::check_role(proxygen::HTTPMessage& msg) 
+        void query_request_handler::check_token(proxygen::HTTPMessage& msg)
         {
             const auto token = get_token(msg, _c.token_header);
 


### PR DESCRIPTION
Customer had access to admin search views. API JS requests search view for my orders page. We need to fix API JS and add the appropriate endpoint in phoenix to get customer orders.