### PR TITLE
[ASHES] Fix: scrolling in search list on key 'down'

### DIFF
--- a/ashes/src/components/live-search/live-search.jsx
+++ b/ashes/src/components/live-search/live-search.jsx
@@ -430,7 +430,9 @@ export default class LiveSearch extends React.Component {
             ? this.state.searchOptions.length - 1
             : this.state.searchOptions.length;
 
-          const newIdx = Math.min(this.state.selectionIndex + 1, maxLength);
+          const newIdx = (this.state.selectionIndex + 1) > maxLength
+            ? 0
+            : this.state.selectionIndex + 1;
 
           let newSearchDisplay;
           if (newIdx < this.state.searchOptions.length) {


### PR DESCRIPTION
It scrolls you to the top when you are on last item and press 'down'