### PR TITLE
Provision Returns feature branch instance

### DIFF
--- a/prov-shit/Makefile
+++ b/prov-shit/Makefile
@@ -35,6 +35,9 @@ deploy-stage:
 deploy-demo:
 	ansible-playbook -v -i bin/envs/staging ansible/test_stage.yml
 
+deploy-returns:
+	ansible-playbook -v -i bin/envs/dev ansible/feature_branch_returns.yml
+
 docker:
 	$(call header, Dockerizing)
 	true

--- a/prov-shit/ansible/feature_branch_returns.yml
+++ b/prov-shit/ansible/feature_branch_returns.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Provision Returns Feature Branch Instance
+  hosts: feature-branch-returns
+  become: true
+  vars:
+    user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    api_server: appliance-10-240-0-12.foxcommerce.com
+    self_host: appliance-10-240-0-12.foxcommerce.com
+    ashes_server_name: appliance-10-240-0-12.foxcommerce.com
+    storefront_server_name: appliance-10-240-0-12.foxcommerce.com
+    with_base_seeds: true
+    url_prefix_perfectgourmet: "/perfect-gourmet"
+    url_prefix_topdrawer: "/top-drawer"
+  roles:
+    - { role: dev/stage_mesos, when: first_run }
+    - { role: dev/zookeeper, when: first_run }
+    - { role: dev/elasticsearch, when: first_run }
+    - { role: dev/db, when: first_run }
+    - { role: hotfix/db }
+    - { role: hotfix/elasticsearch }
+    - { role: hotfix/rsyslog }
+    - { role: prod/migrate_phoenix_db }
+    - { role: prod/migrate_middlewarehouse_db }
+    - { role: dev/stage_mesos, when: first_run }
+    - { role: base/ssh_keys, when: first_run }
+    - { role: hotfix/rsyslog }
+    - { role: dev/marathon }
+    - { role: dev/marathon_consumers }
+    - { role: ext/td/storefront }
+    - { role: ext/tpg/storefront }
+    - { role: dev/balancer }
+    - { role: demo/balancer }
+    - { role: dev/seeder, when: first_run }
+
+  handlers:
+    - include: roles/base/consul_agent/handlers/main.yml

--- a/prov-shit/bin/envs/dev
+++ b/prov-shit/bin/envs/dev
@@ -9,3 +9,6 @@
 
 [kangaroos]
 10.240.0.21
+
+[feature-branch-returns]
+10.240.0.12


### PR DESCRIPTION
## Todo

- [x] Clone Highlander into separate repo and run `make up`
- [x] Create Ansible playbooks, inventory records and `Makefile` entries
- [x] Create fancy DNS record as a companion to default one
- [x] Create special Buildkite pipeline, filtering branches by `feature/returns`
- [x] Merge this to `master`, ask someone to sync `feature/returns` with `master` 

**P.S.** Had to add `buildkite-agent`s SSH key to target instance (because Ansible authorizes only personal key from `make up`), see guide [here](https://www.debian.org/devel/passwordlessssh), public key can be found [here](https://github.com/FoxComm/highlander/tree/master/prov-shit/ansible/roles/base/ssh_keys/files) (encrypted with `ansible-vault`)

**P.P.S.** Additional commands I had to perform on target machine (Ansible bug):

```
sudo su buildkite-agent
sudo mkdir -p /home/buildkite-agent/.ansible
sudo chown buildkite-agent /home/buildkite-agent/.ansible
```

**P.P.P.S.** Another hotfixes:
* 5e09ee02099635b77453dbca1221c13b560998a9 
* 20d31596d5b372a5cf6a4b197c3700f134275e91

## Summary

DNS:
* https://appliance-10-240-0-12.foxcommerce.com/private/dashboard
* https://feature-branch-returns.foxcommerce.com/private/dashboard (created manually)

Buildkite pipeline config: https://buildkite.com/foxcommerce/feature-branch-returns/settings

Related PR: #798 

Potential improvements: 
* ~~We can configure a separate agent (or a queue with single agent targeted to one) for this pipeline to enable power of incremental compilation of `sbt`~~ (disabling clean checkout in Buildkite worked)