### PR TITLE
Kill Marathon tasks for apps with static ports

### DIFF
--- a/tabernacle/ansible/roles/dev/marathon/tasks/app_hyperion.yml
+++ b/tabernacle/ansible/roles/dev/marathon/tasks/app_hyperion.yml
@@ -5,6 +5,12 @@
 - name: Copy Hyperion Marathon JSON
   template: src=hyperion.json dest=/marathon/applications mode="u+rw,g+rw,o+r"
 
+- name: Kill Hyperion Tasks in Marathon
+  shell: 'curl -sS -XDELETE http://{{marathon_server}}/v2/apps/hyperion/tasks'
+
+- name: Pause for a bit...
+  pause: seconds=30
+
 - name: Update Hyperion in Marathon
   shell: 'curl -sS -XPUT -d@/marathon/applications/hyperion.json -H "Content-Type: application/json" http://{{marathon_server}}/v2/apps/hyperion'
 

--- a/tabernacle/ansible/roles/dev/marathon/tasks/app_middlewarehouse.yml
+++ b/tabernacle/ansible/roles/dev/marathon/tasks/app_middlewarehouse.yml
@@ -3,6 +3,12 @@
 - name: Copy Middlewarehouse Marathon JSON
   template: src=middlewarehouse.json dest=/marathon/applications mode="u+rw,g+rw,o+r"
 
+- name: Kill Middlewarehouse Tasks in Marathon
+  shell: 'curl -sS -XDELETE http://{{marathon_server}}/v2/apps/middlewarehouse/tasks'
+
+- name: Pause for a bit...
+  pause: seconds=30
+
 - name: Update Middlewarehouse in Marathon
   shell: 'curl -sS -XPUT -d@/marathon/applications/middlewarehouse.json -H "Content-Type: application/json" http://{{marathon_server}}/v2/apps/middlewarehouse'
 

--- a/tabernacle/ansible/roles/dev/marathon/tasks/app_phoenix.yml
+++ b/tabernacle/ansible/roles/dev/marathon/tasks/app_phoenix.yml
@@ -6,6 +6,12 @@
 - name: Copy Phoenix Marathon JSON
   template: src=phoenix.json dest=/marathon/applications mode="u+rw,g+rw,o+r"
 
+- name: Kill Phoenix Tasks in Marathon
+  shell: 'curl -sS -XDELETE http://{{marathon_server}}/v2/apps/phoenix/tasks'
+
+- name: Pause for a bit...
+  pause: seconds=30
+
 - name: Update Phoenix in Marathon
   shell: 'curl -sS -XPUT -d@/marathon/applications/phoenix.json -H "Content-Type: application/json" http://{{marathon_server}}/v2/apps/phoenix'
 

--- a/tabernacle/ansible/roles/dev/marathon/tasks/app_solomon.yml
+++ b/tabernacle/ansible/roles/dev/marathon/tasks/app_solomon.yml
@@ -5,6 +5,12 @@
 - name: Copy Solomon Marathon JSON
   template: src=solomon.json dest=/marathon/applications mode="u+rw,g+rw,o+r"
 
+- name: Kill Solomon Tasks in Marathon
+  shell: 'curl -sS -XDELETE http://{{marathon_server}}/v2/apps/solomon/tasks'
+
+- name: Pause for a bit...
+  pause: seconds=30
+
 - name: Update Solomon in Marathon
   shell: 'curl -sS -XPUT -d@/marathon/applications/solomon.json -H "Content-Type: application/json" http://{{marathon_server}}/v2/apps/solomon'
 


### PR DESCRIPTION
Apps with static ports get into endless deployment loop because new app instance can't bind to the same port.

I'm doing 30s pauses because app instance termination is not so quick and it can actually pass healthchecks at the bottom of the playbook.