### PR TITLE
Oops! Something went wrong! :P

### DIFF
--- a/phoenix-scala/app/failures/CouponFailures.scala
+++ b/phoenix-scala/app/failures/CouponFailures.scala
@@ -4,10 +4,6 @@ import models.coupon.CouponCodes
 
 object CouponFailures {
 
-  object CouponNotFound {
-    def apply(id: Int) = NotFoundFailure404(s"Coupon $id not found")
-  }
-
   case class CouponNotFoundAtCommit(id: Int, commit: Int) extends Failure {
     override def description = s"Coupon $id not with at commit $commit"
   }

--- a/phoenix-scala/app/failures/CouponFailures.scala
+++ b/phoenix-scala/app/failures/CouponFailures.scala
@@ -8,14 +8,6 @@ object CouponFailures {
     def apply(id: Int) = NotFoundFailure404(s"Coupon $id not found")
   }
 
-  object CouponCodeNotFound {
-    def apply(id: Int) = NotFoundFailure404(s"Coupon code with id=$id not found")
-  }
-
-  object CouponWithCodeCannotBeFound {
-    def apply(code: String) = NotFoundFailure404(s"Coupon with code $code not found")
-  }
-
   case class CouponNotFoundAtCommit(id: Int, commit: Int) extends Failure {
     override def description = s"Coupon $id not with at commit $commit"
   }

--- a/phoenix-scala/app/failures/Failure.scala
+++ b/phoenix-scala/app/failures/Failure.scala
@@ -6,6 +6,8 @@ import utils.friendlyClassName
 
 trait Failure {
   def description: String
+  // Debugging info: code source. Only for development environments!
+  def debug: Option[String] = None
 }
 
 case class GeneralFailure(a: String) extends Failure {

--- a/phoenix-scala/app/failures/NFF.scala
+++ b/phoenix-scala/app/failures/NFF.scala
@@ -3,9 +3,9 @@ package failures
 // Not Found Failure
 object NFF {
 
-  type FailureParam = (String, Any)
+  type FailureParams = Map[String, Any]
 
-  private def formatFailure(entity: String)(params: FailureParam*): String = {
+  private def formatFailure(entity: String)(params: FailureParams): String = {
     val formattedParams: String = params.map {
       case (name, value) ⇒ s"$name=$value"
     }.mkString(", ")
@@ -13,10 +13,10 @@ object NFF {
     s"No $entity with $formattedParams found"
   }
 
-  def notFound404(entity: String)(params: FailureParam*): NotFoundFailure404 =
-    NotFoundFailure404(formatFailure(entity)(params: _*))
+  def notFound404(entity: String)(params: FailureParams): NotFoundFailure404 =
+    NotFoundFailure404(formatFailure(entity)(params))
 
-  def notFound400(entity: String)(params: FailureParam*): NotFoundFailure400 =
-    NotFoundFailure400(formatFailure(entity)(params: _*))
+  def notFound400(entity: String)(params: FailureParams): NotFoundFailure400 =
+    NotFoundFailure400(formatFailure(entity)(params))
 
 }

--- a/phoenix-scala/app/failures/NFF.scala
+++ b/phoenix-scala/app/failures/NFF.scala
@@ -1,0 +1,22 @@
+package failures
+
+// Not Found Failure
+object NFF {
+
+  type FailureParam = (String, Any)
+
+  private def formatFailure(entity: String)(params: FailureParam*): String = {
+    val formattedParams: String = params.map {
+      case (name, value) ⇒ s"$name=$value"
+    }.mkString(", ")
+
+    s"No $entity with $formattedParams found"
+  }
+
+  def notFound404(entity: String)(params: FailureParam*): NotFoundFailure404 =
+    NotFoundFailure404(formatFailure(entity)(params: _*))
+
+  def notFound400(entity: String)(params: FailureParam*): NotFoundFailure400 =
+    NotFoundFailure400(formatFailure(entity)(params: _*))
+
+}

--- a/phoenix-scala/app/failures/PromotionFailures.scala
+++ b/phoenix-scala/app/failures/PromotionFailures.scala
@@ -2,10 +2,6 @@ package failures
 
 object PromotionFailures {
 
-  object PromotionNotFound {
-    def apply(id: Int) = NotFoundFailure404(s"Promotion $id not found")
-  }
-
   case class PromotionNotFoundAtCommit(id: Int, commit: Int) extends Failure {
     override def description = s"Promotion $id not with at commit $commit"
   }
@@ -13,12 +9,6 @@ object PromotionFailures {
   object PromotionShadowNotFoundInPayload {
     def apply(code: String) =
       NotFoundFailure404(s"Promotion shadow with code $code not found in payload")
-  }
-
-  object PromotionNotFoundForContext {
-    def apply(promotionId: Int, contextName: String) =
-      NotFoundFailure404(
-          s"Promotion with id=$promotionId with promotion context $contextName cannot be found")
   }
 
   case object PromotionIsNotActive extends Failure {
@@ -39,11 +29,6 @@ object PromotionFailures {
 
   case object PromotionShadowAttributesAreEmpty extends Failure {
     override def description = "Promotion shadow attributes are empty"
-  }
-
-  case class PromotionShadowNotFoundForContext(shadowId: Int, contextId: Int) extends Failure {
-    override def description =
-      s"Promotion shadow with id=$shadowId not found for contextId=$contextId"
   }
 
   case object OrderHasNoPromotions extends Failure {

--- a/phoenix-scala/app/failures/SomethingWentWrong.scala
+++ b/phoenix-scala/app/failures/SomethingWentWrong.scala
@@ -1,0 +1,19 @@
+package failures
+
+import com.typesafe.scalalogging.LazyLogging
+import slick.driver.PostgresDriver.api._
+import slick.lifted.Query
+import utils.aliases.{SF, SL}
+import utils.codeSource
+
+object SomethingWentWrong extends LazyLogging {
+  def apply(details: String)(implicit sl: SL, sf: SF): GeneralFailure = {
+    logger.error(s"$codeSource: unexpected failure!\n    Details: $details")
+    GeneralFailure("Oops! Something went wrong!")
+  }
+
+  def apply[E, U, C[_]](query: Query[E, U, C])(implicit sl: SL, sf: SF): GeneralFailure = {
+    val sql = query.result.statements.mkString.replaceAll("\"", "")
+    apply(s"unexpected empty result set from query\n    $sql;")
+  }
+}

--- a/phoenix-scala/app/failures/SomethingWentWrong.scala
+++ b/phoenix-scala/app/failures/SomethingWentWrong.scala
@@ -1,19 +1,28 @@
 package failures
 
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import slick.driver.PostgresDriver.api._
 import slick.lifted.Query
 import utils.aliases.{SF, SL}
 import utils.codeSource
 
+case class SomethingWentWrong(desc: String, debugInfo: String) extends Failure {
+  override def description: String   = desc
+  override def debug: Option[String] = debugInfo.some
+}
+
 object SomethingWentWrong extends LazyLogging {
-  def apply(details: String)(implicit sl: SL, sf: SF): GeneralFailure = {
-    logger.error(s"$codeSource: unexpected failure!\n    Details: $details")
-    GeneralFailure("Oops! Something went wrong!")
+  def apply(details: String)(implicit sl: SL, sf: SF): SomethingWentWrong = {
+    val debug = s"$codeSource: unexpected failure!\n    Details: $details"
+    SomethingWentWrong("Oops! Something went wrong!", debug)
   }
 
-  def apply[E, U, C[_]](query: Query[E, U, C])(implicit sl: SL, sf: SF): GeneralFailure = {
-    val sql = query.result.statements.mkString.replaceAll("\"", "")
-    apply(s"unexpected empty result set from query\n    $sql;")
+  def apply[E, U, C[_]](query: Query[E, U, C])(implicit sl: SL, sf: SF): SomethingWentWrong = {
+    val sql = query.result.statements.mkString
+      .replaceAll("\"", "")
+      .replaceAll("from", "\nfrom")
+      .replaceAll("where", "\nwhere")
+    apply(s"unexpected empty result set from query!\n$sql;")
   }
 }

--- a/phoenix-scala/app/models/location/Address.scala
+++ b/phoenix-scala/app/models/location/Address.scala
@@ -128,7 +128,7 @@ object Addresses
     filter(_.accountId === accountId).filter(_.isDefaultShipping === true)
 
   def findByIdAndAccount(addressId: Int, accountId: Int): QuerySeq =
-    findById(addressId).extract.filter(_.accountId === accountId)
+    findById(addressId).filter(_.accountId === accountId)
 
   def findActiveByIdAndAccount(addressId: Int, accountId: Int): QuerySeq =
     findByIdAndAccount(addressId, accountId).filter(_.deletedAt.isEmpty)

--- a/phoenix-scala/app/models/objects/ObjectUtils.scala
+++ b/phoenix-scala/app/models/objects/ObjectUtils.scala
@@ -208,8 +208,8 @@ object ObjectUtils {
              shadowAttributes: Json,
              force: Boolean = false)(implicit db: DB, ec: EC): DbResultT[UpdateResult] =
     for {
-      oldForm   ← * <~ ObjectForms.mustFindById404(formId)
-      oldShadow ← * <~ ObjectShadows.mustFindById404(shadowId)
+      oldForm   ← * <~ ObjectForms.findById(formId)
+      oldShadow ← * <~ ObjectShadows.findById(shadowId)
       result ← * <~ updateFormAndShadow((oldForm, oldShadow),
                                         formAttributes,
                                         shadowAttributes,

--- a/phoenix-scala/app/models/product/MvpModel.scala
+++ b/phoenix-scala/app/models/product/MvpModel.scala
@@ -233,7 +233,7 @@ object Mvp {
                  .filter(_.contextId === oldContextId)
                  .filter(_.id === p.productId)
                  .mustFindOneOr(ProductNotFoundForContext(p.productId, oldContextId))
-      oldForm     ← * <~ ObjectForms.mustFindById404(product.formId)
+      oldForm     ← * <~ ObjectForms.findById(product.formId)
       productForm ← * <~ ObjectForms.update(oldForm, simpleProduct.update(oldForm))
 
       //find sku form for the product and update it with new sku
@@ -244,7 +244,7 @@ object Mvp {
       sku ← * <~ Skus.filter(_.id === link.rightId).mustFindOneOr(SkuNotFound(link.rightId))
 
       simpleSku  ← * <~ SimpleSku(p.code, p.title, p.price, p.currency, p.active, p.tags)
-      oldSkuForm ← * <~ ObjectForms.mustFindById404(sku.formId)
+      oldSkuForm ← * <~ ObjectForms.findById(sku.formId)
       skuForm    ← * <~ ObjectForms.update(oldSkuForm, simpleSku.update(oldSkuForm))
 
       //find album form for the product and update it
@@ -256,7 +256,7 @@ object Mvp {
                .mustFindOneOr(AlbumNotFoundForContext(albumLink.rightId, oldContextId))
 
       simpleAlbum  ← * <~ new SimpleAlbum(p.title, p.image)
-      oldAlbumForm ← * <~ ObjectForms.mustFindById404(album.formId)
+      oldAlbumForm ← * <~ ObjectForms.findById(album.formId)
       albumForm    ← * <~ ObjectForms.update(oldAlbumForm, simpleAlbum.update(oldAlbumForm))
 
       r ← * <~ insertProductIntoContext(contextId,
@@ -502,19 +502,19 @@ object Mvp {
   def getPrice(skuId: Int)(implicit db: DB): DbResultT[Int] =
     for {
       sku    ← * <~ Skus.mustFindById404(skuId)
-      form   ← * <~ ObjectForms.mustFindById404(sku.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      form   ← * <~ ObjectForms.findById(sku.formId)
+      shadow ← * <~ ObjectShadows.findById(sku.shadowId)
       p      ← * <~ priceAsInt(form, shadow)
     } yield p
 
   def getProductTuple(d: SimpleProductData)(implicit db: DB): DbResultT[SimpleProductTuple] =
     for {
       product       ← * <~ Products.mustFindById404(d.productId)
-      productForm   ← * <~ ObjectForms.mustFindById404(product.formId)
-      productShadow ← * <~ ObjectShadows.mustFindById404(product.shadowId)
+      productForm   ← * <~ ObjectForms.findById(product.formId)
+      productShadow ← * <~ ObjectShadows.findById(product.shadowId)
       sku           ← * <~ Skus.mustFindById404(d.skuId)
-      skuForm       ← * <~ ObjectForms.mustFindById404(sku.formId)
-      skuShadow     ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      skuForm       ← * <~ ObjectForms.findById(sku.formId)
+      skuShadow     ← * <~ ObjectShadows.findById(sku.shadowId)
     } yield SimpleProductTuple(product, sku, productForm, skuForm, productShadow, skuShadow)
 
   def insertProducts(ps: Seq[SimpleProductData],

--- a/phoenix-scala/app/responses/SaveForLaterResponse.scala
+++ b/phoenix-scala/app/responses/SaveForLaterResponse.scala
@@ -31,8 +31,8 @@ object SaveForLaterResponse {
              .mustFindOneOr(
                  NotFoundFailure404(s"Save for later entry for sku with id=$skuId not found"))
       sku    ← * <~ Skus.mustFindById404(skuId)
-      form   ← * <~ ObjectForms.mustFindById404(sku.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      form   ← * <~ ObjectForms.findById(sku.formId)
+      shadow ← * <~ ObjectShadows.findById(sku.shadowId)
     } yield build(sfl, sku, form, shadow)
 
   def build(sfl: SaveForLater, sku: Sku, form: ObjectForm, shadow: ObjectShadow): Root = {

--- a/phoenix-scala/app/services/Checkout.scala
+++ b/phoenix-scala/app/services/Checkout.scala
@@ -156,8 +156,8 @@ case class Checkout(
   private def isInventoryTracked(skuCode: String, qty: Int) =
     for {
       sku    ← * <~ SkuManager.mustFindSkuByContextAndCode(contextId = ctx.id, skuCode)
-      shadow ← * <~ ObjectShadows.mustFindById400(sku.shadowId)
-      form   ← * <~ ObjectForms.mustFindById400(shadow.formId)
+      shadow ← * <~ ObjectShadows.findById(sku.shadowId)
+      form   ← * <~ ObjectForms.findById(shadow.formId)
       trackInventory = ObjectUtils.get("trackInventory", form, shadow) match {
         case JBool(trackInv) ⇒ trackInv
         case _               ⇒ true

--- a/phoenix-scala/app/services/CreditCardManager.scala
+++ b/phoenix-scala/app/services/CreditCardManager.scala
@@ -178,7 +178,6 @@ object CreditCardManager {
     val getCardAndAddressChange = for {
       creditCard ← * <~ CreditCards
                     .findById(id)
-                    .extract
                     .filter(_.accountId === accountId)
                     .mustFindOneOr(NotFoundFailure404(CreditCard, id))
       shippingAddress ← * <~ getOptionalShippingAddress(payload.addressId, payload.isShipping)
@@ -232,7 +231,7 @@ object CreditCardManager {
         DBIO.successful(Address.fromOrderShippingAddress(osa).some)
 
       case (None, Some(addressId), _) ⇒
-        Addresses.findById(addressId).extract.one
+        Addresses.findById(addressId).one
 
       case (None, _, Some(createAddress)) ⇒
         DBIO.successful(Address.fromPayload(createAddress, accountId).some)
@@ -245,7 +244,7 @@ object CreditCardManager {
   private def getOptionalShippingAddress(id: Option[Int],
                                          isShipping: Boolean): DBIO[Option[OrderShippingAddress]] =
     id match {
-      case Some(addressId) if isShipping ⇒ OrderShippingAddresses.findById(addressId).extract.one
+      case Some(addressId) if isShipping ⇒ OrderShippingAddresses.findById(addressId).one
       case _                             ⇒ DBIO.successful(None)
     }
 }

--- a/phoenix-scala/app/services/SaveForLaterManager.scala
+++ b/phoenix-scala/app/services/SaveForLaterManager.scala
@@ -17,7 +17,7 @@ object SaveForLaterManager {
 
   def findAll(accountId: Int, contextId: Int)(implicit db: DB, ec: EC): DbResultT[SavedForLater] =
     for {
-      customer ← * <~ Users.mustFindByAccountId(accountId)
+      customer ← * <~ Users.findByAccountId(accountId) ~> Users.notFound404(("id", accountId))
       response ← * <~ findAllDbio(customer, contextId)
     } yield response
 

--- a/phoenix-scala/app/services/SaveForLaterManager.scala
+++ b/phoenix-scala/app/services/SaveForLaterManager.scala
@@ -17,7 +17,7 @@ object SaveForLaterManager {
 
   def findAll(accountId: Int, contextId: Int)(implicit db: DB, ec: EC): DbResultT[SavedForLater] =
     for {
-      customer ← * <~ Users.findByAccountId(accountId) ~> Users.notFound404(("id", accountId))
+      customer ← * <~ Users.findByAccountId(accountId) ~> Users.notFound404(Map("id" → accountId))
       response ← * <~ findAllDbio(customer, contextId)
     } yield response
 

--- a/phoenix-scala/app/services/StoreCreditService.scala
+++ b/phoenix-scala/app/services/StoreCreditService.scala
@@ -67,7 +67,7 @@ object StoreCreditService {
     val reason400 = NotFoundFailure400(Reason, payload.reasonId)
     for {
       customer ← * <~ Users.mustFindByAccountId(accountId)
-      _        ← * <~ Reasons.findById(payload.reasonId).extract.mustFindOneOr(reason400)
+      _        ← * <~ Reasons.findById(payload.reasonId).mustFindOneOr(reason400)
       _        ← * <~ checkSubTypeExists(payload.subTypeId, StoreCredit.CsrAppeasement)
       scope    ← * <~ Scope.resolveOverride(payload.scope)
       manual = StoreCreditManual(adminId = admin.accountId,

--- a/phoenix-scala/app/services/carts/CartShippingAddressUpdater.scala
+++ b/phoenix-scala/app/services/carts/CartShippingAddressUpdater.scala
@@ -18,7 +18,7 @@ import utils.db._
 object CartShippingAddressUpdater {
 
   def mustFindAddressWithRegion(id: Int)(implicit ec: EC): DbResultT[(Address, Region)] =
-    Addresses.findById(id).extract.withRegions.mustFindOneOr(NotFoundFailure404(Address, id))
+    Addresses.findById(id).withRegions.mustFindOneOr(NotFoundFailure404(Address, id))
 
   def mustFindShipAddressForCart(cart: Cart)(implicit ec: EC): DbResultT[OrderShippingAddress] =
     OrderShippingAddresses.findByOrderRef(cart.refNum).mustFindOneOr(NoShipAddress(cart.refNum))

--- a/phoenix-scala/app/services/category/CategoryManager.scala
+++ b/phoenix-scala/app/services/category/CategoryManager.scala
@@ -19,7 +19,7 @@ object CategoryManager {
   def getForm(id: Int)(implicit ec: EC, db: DB): DbResultT[CategoryFormResponse.Root] =
     for {
       category ← * <~ Categories.filterByFormId(id).mustFindOneOr(CategoryFormNotFound(id))
-      form     ← * <~ ObjectForms.mustFindById404(id)
+      form     ← * <~ ObjectForms.findById(id)
     } yield CategoryFormResponse.build(category, form)
 
   def getShadow(formId: Int, contextName: String)(implicit ec: EC,
@@ -29,7 +29,7 @@ object CategoryManager {
       category ← * <~ Categories
                   .withContextAndForm(context.id, formId)
                   .mustFindOneOr(CategoryNotFoundForContext(formId, context.id))
-      shadow ← * <~ ObjectShadows.mustFindById404(category.shadowId)
+      shadow ← * <~ ObjectShadows.findById(category.shadowId)
     } yield CategoryShadowResponse.build(shadow)
 
   def getCategory(categoryId: Int, contextName: String)(
@@ -91,8 +91,8 @@ object CategoryManager {
       commit ← * <~ ObjectCommits
                 .filter(commit ⇒ commit.id === commitId && commit.formId === categoryId)
                 .mustFindOneOr(CategoryNotFoundAtCommit(categoryId, commitId))
-      categoryForm   ← * <~ ObjectForms.mustFindById404(commit.formId)
-      categoryShadow ← * <~ ObjectShadows.mustFindById404(commit.shadowId)
+      categoryForm   ← * <~ ObjectForms.findById(commit.formId)
+      categoryShadow ← * <~ ObjectShadows.findById(commit.shadowId)
     } yield
       IlluminatedCategoryResponse.build(
           IlluminatedCategory.illuminate(context, category, categoryForm, categoryShadow))
@@ -131,7 +131,7 @@ object CategoryManager {
       db: DB): DbResultT[CategoryFull] =
     for {
       category ← * <~ categoryById(categoryId, context)
-      form     ← * <~ ObjectForms.mustFindById404(category.formId)
-      shadow   ← * <~ ObjectShadows.mustFindById404(category.shadowId)
+      form     ← * <~ ObjectForms.findById(category.formId)
+      shadow   ← * <~ ObjectShadows.findById(category.shadowId)
     } yield CategoryFull(context, category, form, shadow)
 }

--- a/phoenix-scala/app/services/coupon/CouponManager.scala
+++ b/phoenix-scala/app/services/coupon/CouponManager.scala
@@ -32,7 +32,7 @@ object CouponManager {
                  .filterByName(contextName)
                  .mustFindOneOr(ObjectContextNotFound(contextName))
       _ ← * <~ Promotions.filterByContextAndFormId(context.id, payload.promotion) ~> Promotions
-           .notFound404(("context", context.name), ("id", payload.promotion))
+           .notFound404(Map("context" → context.name, "id" → payload.promotion))
       ins ← * <~ ObjectUtils.insert(formAndShadow.form, formAndShadow.shadow, payload.schema)
       coupon ← * <~ Coupons.create(
                   Coupon(scope = scope,
@@ -58,7 +58,7 @@ object CouponManager {
                  .filterByName(contextName)
                  .mustFindOneOr(ObjectContextNotFound(contextName))
       _ ← * <~ Promotions.filterByContextAndFormId(context.id, payload.promotion) ~> Promotions
-           .notFound404(("context", context.name), ("id", payload.promotion))
+           .notFound404(Map("context" → context.name, "id" → payload.promotion))
       coupon ← * <~ Coupons
                 .filterByContextAndFormId(context.id, id)
                 .mustFindOneOr(CouponNotFoundForContext(id, contextName))
@@ -90,7 +90,7 @@ object CouponManager {
                  .filterByName(contextName)
                  .mustFindOneOr(ObjectContextNotFound(contextName))
       couponCode ← * <~ CouponCodes.filter(_.code.toLowerCase === code.toLowerCase) ~> Coupons
-                    .notFound404(("code", code))
+                    .notFound404(Map("code" → code))
       result ← * <~ getIlluminatedIntern(couponCode.couponFormId, context)
     } yield result
 

--- a/phoenix-scala/app/services/coupon/CouponManager.scala
+++ b/phoenix-scala/app/services/coupon/CouponManager.scala
@@ -102,8 +102,8 @@ object CouponManager {
                 .filter(_.contextId === context.id)
                 .filter(_.formId === id)
                 .mustFindOneOr(CouponNotFound(id))
-      form   ← * <~ ObjectForms.mustFindById404(coupon.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(coupon.shadowId)
+      form   ← * <~ ObjectForms.findById(coupon.formId)
+      shadow ← * <~ ObjectShadows.findById(coupon.shadowId)
     } yield CouponResponse.build(context, coupon, form, shadow)
 
   def archiveByContextAndId(contextName: String,
@@ -116,8 +116,8 @@ object CouponManager {
                .findOneByContextAndFormId(context.id, formId)
                .mustFindOneOr(NotFoundFailure404(Coupon, formId))
       archiveResult ← * <~ Coupons.update(model, model.copy(archivedAt = Some(Instant.now)))
-      form          ← * <~ ObjectForms.mustFindById404(archiveResult.formId)
-      shadow        ← * <~ ObjectShadows.mustFindById404(archiveResult.shadowId)
+      form          ← * <~ ObjectForms.findById(archiveResult.formId)
+      shadow        ← * <~ ObjectShadows.findById(archiveResult.shadowId)
     } yield CouponResponse.build(context, archiveResult, form, shadow)
 
   def generateCode(id: Int, code: String, admin: User)(implicit ec: EC,

--- a/phoenix-scala/app/services/coupon/CouponUsageService.scala
+++ b/phoenix-scala/app/services/coupon/CouponUsageService.scala
@@ -1,8 +1,8 @@
 package services.coupon
 
 import failures.CouponFailures._
-import models.coupon._
 import models.account.User
+import models.coupon._
 import models.objects.{ObjectContexts, ObjectForms}
 import slick.driver.PostgresDriver.api._
 import utils.aliases._
@@ -59,7 +59,7 @@ object CouponUsageService {
     couponCodeId match {
       case Some(codeId) ⇒
         for {
-          couponCode ← * <~ CouponCodes.findById(codeId).extract.one.safeGet
+          couponCode ← * <~ CouponCodes.findById(codeId)
           context    ← * <~ ObjectContexts.mustFindById400(ctx.id)
           code       ← * <~ CouponCodes.mustFindById400(codeId)
           coupon ← * <~ Coupons

--- a/phoenix-scala/app/services/coupon/CouponUsageService.scala
+++ b/phoenix-scala/app/services/coupon/CouponUsageService.scala
@@ -66,7 +66,7 @@ object CouponUsageService {
                     .filterByContextAndFormId(context.id, code.couponFormId)
                     .one
                     .mustFindOr(CouponNotFoundForContext(code.couponFormId, context.name))
-          form ← * <~ ObjectForms.mustFindById400(coupon.formId)
+          form ← * <~ ObjectForms.findById(coupon.formId)
           couponUsage ← * <~ CouponUsages
                          .filterByCoupon(coupon.formId)
                          .one

--- a/phoenix-scala/app/services/discount/DiscountManager.scala
+++ b/phoenix-scala/app/services/discount/DiscountManager.scala
@@ -21,7 +21,7 @@ object DiscountManager {
     for {
       // guard to make sure the form is a discount
       _    ← * <~ Discounts.filter(_.formId === id).mustFindOneOr(NotFoundFailure404(Discount, id))
-      form ← * <~ ObjectForms.mustFindById404(id)
+      form ← * <~ ObjectForms.findById(id)
     } yield DiscountFormResponse.build(form)
 
   def getShadow(id: Int, contextName: String)(implicit ec: EC,
@@ -34,7 +34,7 @@ object DiscountManager {
                   .filter(_.contextId === context.id)
                   .filter(_.formId === id)
                   .mustFindOneOr(NotFoundFailure404(Discount, id))
-      shadow ← * <~ ObjectShadows.mustFindById404(discount.shadowId)
+      shadow ← * <~ ObjectShadows.findById(discount.shadowId)
     } yield DiscountShadowResponse.build(shadow)
 
   def get(discountId: Int, contextName: String)(implicit ec: EC,
@@ -47,8 +47,8 @@ object DiscountManager {
                   .filter(_.contextId === context.id)
                   .filter(_.formId === discountId)
                   .mustFindOneOr(DiscountNotFoundForContext(discountId, context.id))
-      form   ← * <~ ObjectForms.mustFindById404(discount.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(discount.shadowId)
+      form   ← * <~ ObjectForms.findById(discount.formId)
+      shadow ← * <~ ObjectShadows.findById(discount.shadowId)
     } yield DiscountResponse.build(form, shadow)
 
   def create(
@@ -136,8 +136,8 @@ object DiscountManager {
                   .filter(_.contextId === context.id)
                   .filter(_.formId === id)
                   .mustFindOneOr(NotFoundFailure404(Discount, id))
-      form   ← * <~ ObjectForms.mustFindById404(discount.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(discount.shadowId)
+      form   ← * <~ ObjectForms.findById(discount.formId)
+      shadow ← * <~ ObjectShadows.findById(discount.shadowId)
     } yield
       IlluminatedDiscountResponse.build(
           IlluminatedDiscount.illuminate(context = context.some, form, shadow))

--- a/phoenix-scala/app/services/inventory/SkuManager.scala
+++ b/phoenix-scala/app/services/inventory/SkuManager.scala
@@ -46,8 +46,8 @@ object SkuManager {
   def getSku(code: String)(implicit ec: EC, db: DB, oc: OC): DbResultT[SkuResponse.Root] =
     for {
       sku    ← * <~ SkuManager.mustFindSkuByContextAndCode(oc.id, code)
-      form   ← * <~ ObjectForms.mustFindById404(sku.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      form   ← * <~ ObjectForms.findById(sku.formId)
+      shadow ← * <~ ObjectShadows.findById(sku.shadowId)
       albums ← * <~ ImageManager.getAlbumsForSkuInner(sku.code, oc)
     } yield SkuResponse.build(IlluminatedSku.illuminate(oc, FullObject(sku, form, shadow)), albums)
 
@@ -121,8 +121,8 @@ object SkuManager {
     val code           = getSkuCode(payload.attributes).getOrElse(sku.code)
 
     for {
-      oldForm   ← * <~ ObjectForms.mustFindById404(sku.formId)
-      oldShadow ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      oldForm   ← * <~ ObjectForms.findById(sku.formId)
+      oldShadow ← * <~ ObjectShadows.findById(sku.shadowId)
 
       mergedAttrs = oldShadow.attributes.merge(newShadowAttrs)
       updated ← * <~ ObjectUtils
@@ -197,8 +197,8 @@ object SkuManager {
       implicit ec: EC,
       db: DB): DbResultT[FullObject[Sku]] =
     for {
-      shadow ← * <~ ObjectShadows.mustFindById404(shadowId)
-      form   ← * <~ ObjectForms.mustFindById404(shadow.formId)
+      shadow ← * <~ ObjectShadows.findById(shadowId)
+      form   ← * <~ ObjectForms.findById(shadow.formId)
       sku    ← * <~ Skus.mustFindById404(skuId)
     } yield FullObject(sku, form, shadow)
 

--- a/phoenix-scala/app/services/notes/CouponNoteManager.scala
+++ b/phoenix-scala/app/services/notes/CouponNoteManager.scala
@@ -16,8 +16,8 @@ object CouponNoteManager extends NoteManager[Int, IlluminatedObject] {
       coupon ← * <~ Coupons
                 .filterByContextAndFormId(defaultContextId, id)
                 .mustFindOneOr(CouponNotFoundForDefaultContext(id))
-      form   ← * <~ ObjectForms.mustFindById404(coupon.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(coupon.shadowId)
+      form   ← * <~ ObjectForms.findById(coupon.formId)
+      shadow ← * <~ ObjectShadows.findById(coupon.shadowId)
     } yield IlluminatedObject.illuminate(form = form, shadow = shadow)
 
 }

--- a/phoenix-scala/app/services/notes/PromotionNoteManager.scala
+++ b/phoenix-scala/app/services/notes/PromotionNoteManager.scala
@@ -13,7 +13,7 @@ object PromotionNoteManager extends NoteManager[Int, IlluminatedObject] {
   def fetchEntity(id: Int)(implicit ec: EC, db: DB, ac: AC): DbResultT[IlluminatedObject] =
     for {
       promotion ← * <~ Promotions.filterByContextAndFormId(defaultContextId, id) ~> Promotions
-                   .notFound404(("context", "<default context>"), ("id", id))
+                   .notFound404(Map("context" → "<default context>", "id" → id))
       form   ← * <~ ObjectForms.findById(promotion.formId)
       shadow ← * <~ ObjectShadows.findById(promotion.shadowId)
     } yield IlluminatedObject.illuminate(form = form, shadow = shadow)

--- a/phoenix-scala/app/services/notes/SkuNoteManager.scala
+++ b/phoenix-scala/app/services/notes/SkuNoteManager.scala
@@ -13,7 +13,7 @@ object SkuNoteManager extends NoteManager[String, IlluminatedObject] {
   def fetchEntity(code: String)(implicit ec: EC, db: DB, ac: AC): DbResultT[IlluminatedObject] =
     for {
       sku    ← * <~ SkuManager.mustFindSkuByContextAndCode(defaultContextId, code)
-      form   ← * <~ ObjectForms.mustFindById404(sku.formId)
-      shadow ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      form   ← * <~ ObjectForms.findById(sku.formId)
+      shadow ← * <~ ObjectShadows.findById(sku.shadowId)
     } yield IlluminatedObject.illuminate(form = form, shadow = shadow)
 }

--- a/phoenix-scala/app/services/objects/ObjectManager.scala
+++ b/phoenix-scala/app/services/objects/ObjectManager.scala
@@ -11,16 +11,6 @@ import utils.db._
 
 object ObjectManager {
 
-  def getForm(id: Int)(implicit ec: EC, db: DB): DbResultT[ObjectFormResponse.Root] =
-    for {
-      form ← * <~ ObjectForms.mustFindById404(id)
-    } yield ObjectFormResponse.build(form)
-
-  def getShadow(shadowId: Int)(implicit ec: EC, db: DB): DbResultT[ObjectShadowResponse.Root] =
-    for {
-      shadow ← * <~ ObjectShadows.mustFindById404(shadowId)
-    } yield ObjectShadowResponse.build(shadow)
-
   def getContextByName(name: String)(implicit ec: EC,
                                      db: DB): DbResultT[ObjectContextResponse.Root] =
     for {
@@ -57,8 +47,8 @@ object ObjectManager {
       readHead: ⇒ DbResultT[T])(implicit ec: EC, db: DB): DbResultT[FullObject[T]] =
     for {
       modelHead ← * <~ readHead
-      form      ← * <~ ObjectForms.mustFindById404(modelHead.formId)
-      shadow    ← * <~ ObjectShadows.mustFindById404(modelHead.shadowId)
+      form      ← * <~ ObjectForms.findById(modelHead.formId)
+      shadow    ← * <~ ObjectShadows.findById(modelHead.shadowId)
     } yield FullObject(modelHead, form, shadow)
 
   def getFullObjects[T <: ObjectHead[T]](models: Seq[T])(implicit ec: EC,

--- a/phoenix-scala/app/services/promotion/PromotionManager.scala
+++ b/phoenix-scala/app/services/promotion/PromotionManager.scala
@@ -97,7 +97,7 @@ object PromotionManager {
                  .filterByName(contextName)
                  .mustFindOneOr(ObjectContextNotFound(contextName))
       promotion ← * <~ Promotions.filterByContextAndFormId(context.id, id) ~> Promotions
-                   .notFound404(("context", context.name), ("id", id))
+                   .notFound404(Map("context" → context.name, "id" → id))
       validated = IlluminatedPromotion
         .validatePromotion(payload.applyType, (formAndShadow.form, formAndShadow.shadow))
 
@@ -183,8 +183,8 @@ object PromotionManager {
                  .mustFindOneOr(ObjectContextNotFound(contextName))
       promotion ← * <~ Promotions
                    .filter(_.contextId === context.id)
-                   .filter(_.formId === id) ~> Promotions.notFound404(("context", context.name),
-                                                                      ("id", id))
+                   .filter(_.formId === id) ~> Promotions.notFound404(
+                     Map("context" → context.name, "id" → id))
       form      ← * <~ ObjectForms.findById(promotion.formId)
       shadow    ← * <~ ObjectShadows.findById(promotion.shadowId)
       discounts ← * <~ PromotionDiscountLinks.queryRightByLeft(promotion)

--- a/phoenix-scala/app/services/promotion/PromotionManager.scala
+++ b/phoenix-scala/app/services/promotion/PromotionManager.scala
@@ -2,12 +2,10 @@ package services.promotion
 
 import java.time.Instant
 
-import com.github.tminglei.slickpg.LTree
 import failures.NotFoundFailure404
 import failures.ObjectFailures._
-import failures.PromotionFailures._
-import models.coupon.Coupons
 import models.account._
+import models.coupon.Coupons
 import models.discount._
 import models.objects.ObjectUtils._
 import models.objects._
@@ -98,9 +96,8 @@ object PromotionManager {
       context ← * <~ ObjectContexts
                  .filterByName(contextName)
                  .mustFindOneOr(ObjectContextNotFound(contextName))
-      promotion ← * <~ Promotions
-                   .filterByContextAndFormId(context.id, id)
-                   .mustFindOneOr(PromotionNotFoundForContext(id, contextName))
+      promotion ← * <~ Promotions.filterByContextAndFormId(context.id, id) ~> Promotions
+                   .notFound404(("context", context.name), ("id", id))
       validated = IlluminatedPromotion
         .validatePromotion(payload.applyType, (formAndShadow.form, formAndShadow.shadow))
 
@@ -186,8 +183,8 @@ object PromotionManager {
                  .mustFindOneOr(ObjectContextNotFound(contextName))
       promotion ← * <~ Promotions
                    .filter(_.contextId === context.id)
-                   .filter(_.formId === id)
-                   .mustFindOneOr(PromotionNotFound(id))
+                   .filter(_.formId === id) ~> Promotions.notFound404(("context", context.name),
+                                                                      ("id", id))
       form      ← * <~ ObjectForms.mustFindById404(promotion.formId)
       shadow    ← * <~ ObjectShadows.mustFindById404(promotion.shadowId)
       discounts ← * <~ PromotionDiscountLinks.queryRightByLeft(promotion)

--- a/phoenix-scala/app/services/promotion/PromotionManager.scala
+++ b/phoenix-scala/app/services/promotion/PromotionManager.scala
@@ -185,8 +185,8 @@ object PromotionManager {
                    .filter(_.contextId === context.id)
                    .filter(_.formId === id) ~> Promotions.notFound404(("context", context.name),
                                                                       ("id", id))
-      form      ← * <~ ObjectForms.mustFindById404(promotion.formId)
-      shadow    ← * <~ ObjectShadows.mustFindById404(promotion.shadowId)
+      form      ← * <~ ObjectForms.findById(promotion.formId)
+      shadow    ← * <~ ObjectShadows.findById(promotion.shadowId)
       discounts ← * <~ PromotionDiscountLinks.queryRightByLeft(promotion)
     } yield
       PromotionResponse.build(

--- a/phoenix-scala/app/services/returns/ReturnLineItemUpdater.scala
+++ b/phoenix-scala/app/services/returns/ReturnLineItemUpdater.scala
@@ -29,7 +29,7 @@ object ReturnLineItemUpdater {
                 .filter(_.id === payload.reasonId)
                 .mustFindOneOr(NotFoundFailure400(ReturnReason, payload.reasonId))
       sku       ← * <~ SkuManager.mustFindSkuByContextAndCode(context.id, payload.sku)
-      skuShadow ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      skuShadow ← * <~ ObjectShadows.findById(sku.shadowId)
       // Inserts
       origin ← * <~ ReturnLineItemSkus.create(
                   ReturnLineItemSku(returnId = rma.id, skuId = sku.id, skuShadowId = skuShadow.id))

--- a/phoenix-scala/app/services/variant/VariantManager.scala
+++ b/phoenix-scala/app/services/variant/VariantManager.scala
@@ -193,8 +193,8 @@ object VariantManager {
 
     for {
       value     ← * <~ mustFindVariantValueByContextAndForm(contextId, valueId)
-      oldForm   ← * <~ ObjectForms.mustFindById404(value.formId)
-      oldShadow ← * <~ ObjectShadows.mustFindById404(value.shadowId)
+      oldForm   ← * <~ ObjectForms.findById(value.formId)
+      oldShadow ← * <~ ObjectShadows.findById(value.shadowId)
 
       mergedAttrs = oldShadow.attributes.merge(shadow.attributes)
       updated ← * <~ ObjectUtils

--- a/phoenix-scala/app/utils/db/FoxTableQuery.scala
+++ b/phoenix-scala/app/utils/db/FoxTableQuery.scala
@@ -1,8 +1,8 @@
 package utils.db
 
 import cats.data.Xor
-import failures.{Failure, Failures}
-import slick.dbio.DBIO
+import failures.NFF._
+import failures._
 import slick.driver.PostgresDriver.api._
 import slick.lifted.{TableQuery, Tag}
 import utils.aliases._
@@ -15,7 +15,7 @@ abstract class FoxTableQuery[M <: FoxModel[M], T <: FoxTable[M]](construct: Tag 
 
   import ExceptionWrapper._
 
-  def tableName: String = baseTableRow.tableName
+  val tableName: String = baseTableRow.tableName
 
   private val compiledById = this.findBy(_.id)
 
@@ -26,6 +26,12 @@ abstract class FoxTableQuery[M <: FoxModel[M], T <: FoxTable[M]](construct: Tag 
 
   def findAllByIds(ids: Set[M#Id]): QuerySeq =
     filter(_.id.inSet(ids))
+
+  def notFound404(params: FailureParam*): NotFoundFailure404 =
+    NFF.notFound404(tableName)(params: _*)
+
+  def f400(params: FailureParam*): NotFoundFailure400 =
+    NFF.notFound400(tableName)(params: _*)
 
   private def returningTable: Returning[M, Ret] = this.returning(returningQuery)
 

--- a/phoenix-scala/app/utils/db/FoxTableQuery.scala
+++ b/phoenix-scala/app/utils/db/FoxTableQuery.scala
@@ -27,11 +27,11 @@ abstract class FoxTableQuery[M <: FoxModel[M], T <: FoxTable[M]](construct: Tag 
   def findAllByIds(ids: Set[M#Id]): QuerySeq =
     filter(_.id.inSet(ids))
 
-  def notFound404(params: FailureParam*): NotFoundFailure404 =
-    NFF.notFound404(tableName)(params: _*)
+  def notFound404(params: FailureParams): NotFoundFailure404 =
+    NFF.notFound404(tableName)(params)
 
-  def notFound400(params: FailureParam*): NotFoundFailure400 =
-    NFF.notFound400(tableName)(params: _*)
+  def notFound400(params: FailureParams): NotFoundFailure400 =
+    NFF.notFound400(tableName)(params)
 
   private def returningTable: Returning[M, Ret] = this.returning(returningQuery)
 

--- a/phoenix-scala/app/utils/db/FoxTableQuery.scala
+++ b/phoenix-scala/app/utils/db/FoxTableQuery.scala
@@ -30,7 +30,7 @@ abstract class FoxTableQuery[M <: FoxModel[M], T <: FoxTable[M]](construct: Tag 
   def notFound404(params: FailureParam*): NotFoundFailure404 =
     NFF.notFound404(tableName)(params: _*)
 
-  def f400(params: FailureParam*): NotFoundFailure400 =
+  def notFound400(params: FailureParam*): NotFoundFailure400 =
     NFF.notFound400(tableName)(params: _*)
 
   private def returningTable: Returning[M, Ret] = this.returning(returningQuery)

--- a/phoenix-scala/app/utils/db/FoxTableQuery.scala
+++ b/phoenix-scala/app/utils/db/FoxTableQuery.scala
@@ -19,7 +19,7 @@ abstract class FoxTableQuery[M <: FoxModel[M], T <: FoxTable[M]](construct: Tag 
 
   private val compiledById = this.findBy(_.id)
 
-  def findById(i: M#Id) = compiledById(i)
+  def findById(i: M#Id) = compiledById(i).extract
 
   def findOneById(i: M#Id): DBIO[Option[M]] =
     findById(i).result.headOption
@@ -72,7 +72,7 @@ abstract class FoxTableQuery[M <: FoxModel[M], T <: FoxTable[M]](construct: Tag 
       _        ← * <~ oldModel.mustBeCreated
       prepared ← * <~ beforeSave(newModel)
       _        ← * <~ oldModel.updateTo(prepared)
-      returned ← * <~ findById(oldModel.id).extract.updateReturningHead(returningQuery, prepared)
+      returned ← * <~ findById(oldModel.id).updateReturningHead(returningQuery, prepared)
     } yield returningLens.set(prepared)(returned)
 
   protected def beforeSave(model: M): Failures Xor M =

--- a/phoenix-scala/app/utils/db/Star.scala
+++ b/phoenix-scala/app/utils/db/Star.scala
@@ -4,10 +4,11 @@ import scala.collection.generic.CanBuildFrom
 import scala.concurrent.Future
 
 import cats.data.{Validated, Xor}
-import failures.Failures
+import failures.{Failure, Failures}
 import slick.dbio._
+import slick.lifted.Query
 import slick.profile.SqlAction
-import utils.aliases.EC
+import utils.aliases._
 
 object * {
   def <~[A](v: DBIO[Failures Xor A]): DbResultT[A] =
@@ -46,4 +47,11 @@ object * {
     v.fold(DbResultT.none[A]) { dbresult ⇒
       dbresult.map(Some(_))
     }
+
+  def <~[A, C[_]](query: Query[_, A, C])(implicit ec: EC, sl: SL, sf: SF): DbResultT[A] =
+    DbResultT.nonEmptyQuery(query)
+
+  def <~[A, C[_]](query: Query[_, A, C],
+                  failure: Failure)(implicit ec: EC, sl: SL, sf: SF): DbResultT[A] =
+    DbResultT.nonEmptyQuery(query, failure)
 }

--- a/phoenix-scala/app/utils/db/package.scala
+++ b/phoenix-scala/app/utils/db/package.scala
@@ -125,6 +125,9 @@ package object db {
 
     def mustNotFindOneOr(notFoundFailure: Failure)(implicit ec: EC): DbResultT[Unit] =
       query.one.mustNotFindOr(notFoundFailure)
+
+    def ~>(failure: Failure)(implicit ec: EC): DbResultT[U] =
+      DbResultT.nonEmptyQuery(query, failure)
   }
 
   implicit class RunOnDbIO[R](val dbio: DBIO[R]) extends AnyVal {

--- a/phoenix-scala/app/utils/db/package.scala
+++ b/phoenix-scala/app/utils/db/package.scala
@@ -62,6 +62,9 @@ package object db {
         case NonEmptyList(h, t) ⇒ NonEmptyList(mapFailure(h), t.map(mapFailure))
       }
     }
+
+    def asOption(implicit ec: EC): DbResultT[Option[A]] =
+      XorT(dbResultT.fold(_ ⇒ Xor.right(None), value ⇒ Xor.right(Some(value))))
   }
 
   final implicit class EnrichedOption[A](val option: Option[A]) extends AnyVal {

--- a/phoenix-scala/app/utils/db/package.scala
+++ b/phoenix-scala/app/utils/db/package.scala
@@ -65,6 +65,9 @@ package object db {
 
     def asOption(implicit ec: EC): DbResultT[Option[A]] =
       XorT(dbResultT.fold(_ ⇒ Xor.right(None), value ⇒ Xor.right(Some(value))))
+
+    def ~>(newFailure: Failure)(implicit ec: EC): DbResultT[A] =
+      dbResultT.leftMap(_ ⇒ newFailure.single)
   }
 
   final implicit class EnrichedOption[A](val option: Option[A]) extends AnyVal {

--- a/phoenix-scala/app/utils/http/Http.scala
+++ b/phoenix-scala/app/utils/http/Http.scala
@@ -1,15 +1,17 @@
 package utils.http
 
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, ResponseEntity, StatusCode, StatusCodes}
+import akka.http.scaladsl.model._
 
-import cats.implicits._
-import failures.{Failures, NotFoundFailure404}
+import com.typesafe.scalalogging.LazyLogging
+import failures.{Failure, Failures, NotFoundFailure404}
+import org.json4s.JsonDSL._
 import org.json4s.jackson.Serialization
 import org.json4s.jackson.Serialization.{write ⇒ json}
 import org.json4s.{Formats, jackson}
+import utils.Environment
 
-object Http {
+object Http extends LazyLogging {
   import utils.JsonFormatters._
 
   implicit lazy val serialization: Serialization.type = jackson.Serialization
@@ -20,7 +22,7 @@ object Http {
   val badRequestResponse: HttpResponse = HttpResponse(BadRequest)
 
   private def renderNotFoundFailure(f: NotFoundFailure404): HttpResponse =
-    notFoundResponse.copy(entity = jsonEntity("errors" → Seq(f.message)))
+    notFoundResponse.copy(entity = errorsJson(Seq(f)))
 
   def render[A <: AnyRef](resource: A, statusCode: StatusCode = OK) =
     HttpResponse(statusCode, entity = jsonEntity(resource))
@@ -31,13 +33,30 @@ object Http {
   def renderFailure(failures: Failures, statusCode: ClientError = BadRequest): HttpResponse = {
     val failuresList = failures.toList
     val notFound     = failuresList.collectFirst { case f: NotFoundFailure404 ⇒ f }
-    notFound.fold(HttpResponse(statusCode,
-                               entity = jsonEntity("errors" → failuresList.map(_.description)))) {
-      nf ⇒
-        renderNotFoundFailure(nf)
+    notFound.fold(HttpResponse(statusCode, entity = errorsJson(failuresList))) { nf ⇒
+      renderNotFoundFailure(nf)
     }
   }
 
   def jsonEntity[A <: AnyRef](resource: A): ResponseEntity =
     HttpEntity(ContentTypes.`application/json`, json(resource))
+
+  def errorsJson(failures: Seq[Failure]): ResponseEntity = {
+    val errorsJson = "errors" → failures.map(_.description)
+
+    val allFailuresDebug = failures.map(_.debug)
+
+    // Logging only at HTTP error response render so we don't get logs clogged with errors that were silenced
+    // with `DbResultT#fold` or any other way
+    if (allFailuresDebug.count(_.nonEmpty) > 0) logger.error(allFailuresDebug.mkString("\n"))
+
+    if (Environment.default.isProd)
+      jsonEntity(errorsJson)
+    else {
+      // Replace \n line breaks with JSON array ¯\_(ツ)_/¯
+      val debugJson = "debug" → allFailuresDebug.map(_.map(_.split("\n").toList))
+      // Append debug info to errors
+      jsonEntity(errorsJson ~ debugJson)
+    }
+  }
 }

--- a/phoenix-scala/app/utils/package.scala
+++ b/phoenix-scala/app/utils/package.scala
@@ -1,5 +1,7 @@
 import scala.language.implicitConversions
+
 import utils.Strings._
+import utils.aliases.{SF, SL}
 
 package object utils {
   def generateUuid: String = java.util.UUID.randomUUID.toString
@@ -14,6 +16,9 @@ package object utils {
     "[A-Z\\d]".r.replaceAllIn(name, { m ⇒
       "_" + m.group(0).toLowerCase
     })
+
+  def codeSource(implicit line: SL, file: SF): String =
+    s"""${file.value.split("/").last}:${line.value}"""
 
   implicit class OptionError[A](val o: Option[A]) extends AnyVal {
     def getOrError(text: String): A = o.getOrElse {

--- a/phoenix-scala/test/integration/ActivityTrailIntegrationTest.scala
+++ b/phoenix-scala/test/integration/ActivityTrailIntegrationTest.scala
@@ -168,7 +168,7 @@ class ActivityTrailIntegrationTest
   }
 
   def getConnection(id: Int): Connection =
-    Connections.findById(id).extract.result.head.gimme
+    Connections.findById(id).result.head.gimme
 
   def appendActivity(dimension: String, objectId: Int, activityId: Int): Root =
     activityTrailsApi

--- a/phoenix-scala/test/integration/CartIntegrationTest.scala
+++ b/phoenix-scala/test/integration/CartIntegrationTest.scala
@@ -1,12 +1,13 @@
 import akka.http.scaladsl.model.StatusCodes
+
 import cats.implicits._
 import failures.CartFailures._
 import failures.LockFailures._
 import failures.ShippingMethodFailures._
 import failures.{NotFoundFailure400, NotFoundFailure404}
 import faker.Lorem
-import models.cord._
 import models.cord.lineitems._
+import models.cord._
 import models.location._
 import models.payment.creditcard._
 import models.product.Mvp
@@ -14,16 +15,15 @@ import models.rules.QueryStatement
 import models.shipping._
 import org.json4s.jackson.JsonMethods._
 import payloads.AddressPayloads.{CreateAddressPayload, UpdateAddressPayload}
-import payloads.CustomerPayloads.CreateCustomerPayload
-import payloads.LineItemPayloads._
 import payloads.CartPayloads.CreateCart
+import payloads.CustomerPayloads.CreateCustomerPayload
+import payloads.GiftCardPayloads.GiftCardCreateByCsr
+import payloads.LineItemPayloads._
+import payloads.PaymentPayloads._
 import payloads.UpdateShippingMethod
+import responses._
 import responses.cord.CartResponse
 import responses.cord.base.CordResponseLineItem
-import responses._
-import models.cord.CordPaymentState
-import payloads.GiftCardPayloads.GiftCardCreateByCsr
-import payloads.PaymentPayloads._
 import services.carts.CartTotaler
 import slick.driver.PostgresDriver.api._
 import testutils._
@@ -50,7 +50,7 @@ class CartIntegrationTest
       }
 
       "displays 'auth' payment state" in new PaymentStateFixture {
-        CreditCardCharges.findById(ccc.id).extract.map(_.state).update(CreditCardCharge.Auth).gimme
+        CreditCardCharges.findById(ccc.id).map(_.state).update(CreditCardCharge.Auth).gimme
 
         val fullCart = cartsApi(cart.refNum).get().asTheResult[CartResponse]
         fullCart.paymentState must === (CordPaymentState.Auth)

--- a/phoenix-scala/test/integration/CustomerIntegrationTest.scala
+++ b/phoenix-scala/test/integration/CustomerIntegrationTest.scala
@@ -206,8 +206,8 @@ class CustomerIntegrationTest
         sql"SELECT public.update_customers_ranking()".as[Boolean].gimme
 
         customersApi(customer.accountId).get().as[Root].rank must === (2.some)
-        val rank  = CustomersRanks.findById(customer.accountId).extract.result.head.gimme
-        val rank2 = CustomersRanks.findById(customer2.accountId).extract.result.head.gimme
+        val rank  = CustomersRanks.findById(customer.accountId).result.head.gimme
+        val rank2 = CustomersRanks.findById(customer2.accountId).result.head.gimme
 
         rank.revenue must === (charge1.amount)
         rank2.revenue must === (charge2.amount)

--- a/phoenix-scala/test/integration/ReturnNotesIntegrationTest.scala
+++ b/phoenix-scala/test/integration/ReturnNotesIntegrationTest.scala
@@ -91,9 +91,7 @@ class ReturnNotesIntegrationTest
           POST(s"v1/notes/rma/${rma.refNum}", CreateNote(body = "Hello, FoxCommerce!"))
         val note = createResp.as[AdminNotes.Root]
 
-        val response = DELETE(s"v1/notes/rma/${rma.refNum}/${note.id}")
-        response.status must === (StatusCodes.NoContent)
-        response.bodyText mustBe empty
+        DELETE(s"v1/notes/rma/${rma.refNum}/${note.id}").mustBeEmpty()
 
         val updatedNote = Notes.findOneById(note.id).run().futureValue.value
         updatedNote.deletedBy.value must === (1)

--- a/phoenix-scala/test/integration/SaveForLaterIntegrationTest.scala
+++ b/phoenix-scala/test/integration/SaveForLaterIntegrationTest.scala
@@ -29,7 +29,7 @@ class SaveForLaterIntegrationTest
     }
 
     "404 if customer is not found" in {
-      saveForLaterApi(666).get().mustFailWith404(Users.notFound404(("id", 666)))
+      saveForLaterApi(666).get().mustFailWith404(Users.notFound404(Map("id" → 666)))
     }
   }
 

--- a/phoenix-scala/test/integration/SaveForLaterIntegrationTest.scala
+++ b/phoenix-scala/test/integration/SaveForLaterIntegrationTest.scala
@@ -29,7 +29,7 @@ class SaveForLaterIntegrationTest
     }
 
     "404 if customer is not found" in {
-      saveForLaterApi(666).get().mustFailWith404(NotFoundFailure404(User, 666))
+      saveForLaterApi(666).get().mustFailWith404(Users.notFound404(("id", 666)))
     }
   }
 

--- a/phoenix-scala/test/integration/services/CartValidatorTest.scala
+++ b/phoenix-scala/test/integration/services/CartValidatorTest.scala
@@ -147,11 +147,11 @@ class CartValidatorTest extends IntegrationTestBase with TestObjectContext with 
     val (product, productForm, productShadow, sku, skuForm, skuShadow, items) = (for {
       productData   ← * <~ Mvp.insertProduct(ctx.id, Factories.products.head)
       product       ← * <~ Products.mustFindById404(productData.productId)
-      productForm   ← * <~ ObjectForms.mustFindById404(product.formId)
-      productShadow ← * <~ ObjectShadows.mustFindById404(product.shadowId)
+      productForm   ← * <~ ObjectForms.findById(product.formId)
+      productShadow ← * <~ ObjectShadows.findById(product.shadowId)
       sku           ← * <~ Skus.mustFindById404(productData.skuId)
-      skuForm       ← * <~ ObjectForms.mustFindById404(sku.formId)
-      skuShadow     ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      skuForm       ← * <~ ObjectForms.findById(sku.formId)
+      skuShadow     ← * <~ ObjectShadows.findById(sku.shadowId)
       items         ← * <~ CartLineItems.create(CartLineItem(cordRef = cart.refNum, skuId = sku.id))
       _             ← * <~ CartTotaler.saveTotals(cart)
     } yield (product, productForm, productShadow, sku, skuForm, skuShadow, items)).gimme
@@ -163,11 +163,11 @@ class CartValidatorTest extends IntegrationTestBase with TestObjectContext with 
     val (product, productForm, productShadow, sku, skuForm, skuShadow, items) = (for {
       productData   ← * <~ Mvp.insertProduct(ctx.id, Factories.products.head.copy(price = 0))
       product       ← * <~ Products.mustFindById404(productData.productId)
-      productForm   ← * <~ ObjectForms.mustFindById404(product.formId)
-      productShadow ← * <~ ObjectShadows.mustFindById404(product.shadowId)
+      productForm   ← * <~ ObjectForms.findById(product.formId)
+      productShadow ← * <~ ObjectShadows.findById(product.shadowId)
       sku           ← * <~ Skus.mustFindById404(productData.skuId)
-      skuForm       ← * <~ ObjectForms.mustFindById404(sku.formId)
-      skuShadow     ← * <~ ObjectShadows.mustFindById404(sku.shadowId)
+      skuForm       ← * <~ ObjectForms.findById(sku.formId)
+      skuShadow     ← * <~ ObjectShadows.findById(sku.shadowId)
       items         ← * <~ CartLineItems.create(CartLineItem(cordRef = cart.refNum, skuId = sku.id))
       _             ← * <~ CartTotaler.saveTotals(cart)
     } yield (product, productForm, productShadow, sku, skuForm, skuShadow, items)).gimme

--- a/phoenix-scala/test/integration/testutils/package.scala
+++ b/phoenix-scala/test/integration/testutils/package.scala
@@ -1,18 +1,19 @@
 import scala.concurrent.Await._
 import scala.concurrent.duration._
 import akka.http.scaladsl.model.{HttpResponse, StatusCode, StatusCodes}
+
 import failures.Failure
 import org.json4s.Formats
 import org.json4s.jackson.JsonMethods._
-import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest._
+import org.scalatest.concurrent.PatienceConfiguration
 import responses.TheResponse
 import utils.aliases._
 
 package object testutils {
 
   def originalSourceClue(implicit line: SL, file: SF) =
-    s"""\n(Original source: ${file.value.split("/").last}:${line.value})"""
+    s"\n(Original source: ${utils.codeSource})"
 
   type FoxSuite = TestSuite with PatienceConfiguration with DbTestSupport
 


### PR DESCRIPTION
**14 June 2017: I decided to keep this branch and PR for future reference** -- Anna



A new approach to fetching entities: just type in query, `DbResultT` will assume you want the only entity found.
If you are fetching something by FK, just leave the query in for comprehension as is. If it fails, client will get "Oops! Something went wrong!" error message, and phoenix will log the exact query that failed.
If you want to error out explicitly (e.g. you fetch entity by a request param or payload value), chain a failure with `~>`.
I also defined a helper for generating not found failures for tables with explicit param specification.
WDYT?