### PR TITLE
Add chanID to product recommender route

### DIFF
--- a/intelligence/cross-sell/.gitignore
+++ b/intelligence/cross-sell/.gitignore
@@ -1,1 +1,3 @@
 */src/__pycache__/
+# Ignore ctags generated for IDE indexers
+tags

--- a/intelligence/cross-sell/prod-prod/src/PPRecommend.py
+++ b/intelligence/cross-sell/prod-prod/src/PPRecommend.py
@@ -7,14 +7,14 @@ class PPRecommend(object):
         self.events = set()
         self.upToDate = False
 
-    def add_point(self, custID, prodID):
+    def add_point(self, custID, prodID, chanID):
         """add_point
-        takes and event 'custID purchased prodID' and adds it to
+        takes and event 'custID purchased prodID, channel ID' and adds it to
         the recommender data.
         The sparse matrix needs to be recomputed before making more
         recommendations.
         """
-        self.events.add((custID, prodID))
+        self.events.add((custID, prodID, chanID))
         self.upToDate = False
 
     def make_matrix(self):
@@ -31,19 +31,19 @@ class PPRecommend(object):
         these are the values to go in the sparse matrix so that the columns are
         l2 normalized. 
         """
-        return np.array([1.0/sqrt(self.count(x)) for (_, x) in self.events])
+        return np.array([1.0/sqrt(self.count(x)) for (_, x, _) in self.events])
 
     def count(self, prodID):
         """how many customers have purchased product prodID
         """
-        return len([prod for (_, prod) in self.events if prod == prodID])
+        return len([prod for (_, prod, _) in self.events if prod == prodID])
 
     def coords(self):
         """list of pairs (custID, prodID) where custID has purchased prodID
         """
         return (
-            [custID for (custID, _) in self.events],
-            [prodID for (_, prodID) in self.events]
+            [custID for (custID, _, _) in self.events],
+            [prodID for (_, prodID, _) in self.events]
         )
 
     def recommend(self, prodID):
@@ -58,7 +58,7 @@ class PPRecommend(object):
         v = self.mat[:, prodID].toarray()
         inds = np.argsort(v.T[0])[::-1]
         out = {'products': [{'id': np.asscalar(x), 'score': np.asscalar(y)}
-                for (x, y) in zip(inds, v[inds].T[0])
-                if x != int(prodID)]}
+                            for (x, y) in zip(inds, v[inds].T[0])
+                            if x != int(prodID)]}
 
         return out

--- a/intelligence/cross-sell/prod-prod/src/router.py
+++ b/intelligence/cross-sell/prod-prod/src/router.py
@@ -17,5 +17,5 @@ def rec_prod_prod(prod_id):
 def train():
     json_dict = request.get_json()
     for point in json_dict['points']:
-        pprec.add_point(point['custID'], point['prodID'])
+        pprec.add_point(point['custID'], point['prodID'], point['chanID'])
     return ""


### PR DESCRIPTION
## Description

- Adds channel ID value as an additional property for products stored in the set of PPRecommend events
- The POST request made to `/recommend/prod-prod/train` now requires a third key `chanID`

### Example
```
{
  "points": [
  {
	"custID": 1,
	"prodID": 4,
	"chanID": 1
  },
  {
	"custID": 1,
	"prodID": 5,
	"chanID": 1
  },
  {
	"custID": 1,
	"prodID": 6,
	"chanID": 1
  }
  ]
}
```