### PR TITLE
raise proper exception for notes search view trigger when case not found

### DIFF
--- a/phoenix-scala/sql/R__notes_search_view_triggers.sql
+++ b/phoenix-scala/sql/R__notes_search_view_triggers.sql
@@ -132,6 +132,9 @@ begin
               into strict new_note.return
               from returns
               where returns.id = new.reference_id;
+      else
+        RAISE EXCEPTION 'Nonexistent reference_type ---> %', new.reference_type
+        USING HINT = 'Please check if you have appropriate case mentioned above';
     end case;
 
     select new.scope into strict new_note.scope;


### PR DESCRIPTION
Way to have more nice and friendly error message when you do something new your trigger is mad at you for no reason
```
[info]     Errors: List(ERROR: Nonexistent reference_type ---> return
[info]       Подсказка: Please check if you have appropriate case mentioned above
[info]       Где: PL/pgSQL function update_notes_search_view_insert_fn() line 135 at RAISE)!
```