### PR TITLE
Fix Flyway search_path for Bernardo

### DIFF
--- a/intelligence/bernardo/sql/beforeEachMigrate.sql
+++ b/intelligence/bernardo/sql/beforeEachMigrate.sql
@@ -1,0 +1,23 @@
+DO $$
+DECLARE
+    default_search_path TEXT := NULL;
+BEGIN
+    SELECT setting_value INTO default_search_path
+    FROM (
+        SELECT
+            substring(setting from 1 for eq_position - 1) AS setting_name,
+            substring(setting from eq_position + 1) AS setting_value
+        FROM (
+            SELECT position('=' in setting) AS eq_position, setting
+            FROM (
+                SELECT UNNEST(setconfig) AS setting FROM pg_db_role_setting s JOIN pg_database d ON s.setdatabase = d.oid WHERE d.datname = current_database()
+            ) raw_db_role_settings
+        ) presplit_db_role_settings
+    ) split_db_role_settings
+    WHERE setting_name = 'search_path';
+
+    IF default_search_path IS NOT NULL THEN
+        EXECUTE 'SET search_path = '||default_search_path;
+    END IF;
+END;
+$$


### PR DESCRIPTION
From time to time, Bernardo migrations fail:

```
TASK [dev/db_ic : Clean Bernardo Database] *************************************
fatal: [10.240.0.18]: FAILED! => {"changed": true, "cmd": "FLYWAY_HOME=/usr/local/share/flyway-4.0.3 /usr/local/share/flyway-4.0.3/flyway -locations=filesystem:sql/ -configFile=sql/flyway.conf clean", "delta": "0:00:00.413555", "end": "2017-03-07 11:33:21.889583", "failed": true, "rc": 1, "start": "2017-03-07 11:33:21.476028", "stderr": "ERROR: Unable to clean schema \"public\"", "stdout": "Flyway 4.0.3 by Boxfuse\n\nDatabase: jdbc:postgresql://db.service.consul/ic?user=root (PostgreSQL 9.5)", "stdout_lines": ["Flyway 4.0.3 by Boxfuse", "", "Database: jdbc:postgresql://db.service.consul/ic?user=root (PostgreSQL 9.5)"], "warnings": []}
```

This is an old Flyway bug, fixed by this workaround: https://github.com/flyway/flyway/issues/1379#issuecomment-236247975

We already applied this for Phoenix in #207