### PR TITLE
Fix an ~off-by-one error that happens in 1‰ cases

### DIFF
--- a/phoenix-scala/test/unit/models/CouponCodeTest.scala
+++ b/phoenix-scala/test/unit/models/CouponCodeTest.scala
@@ -26,7 +26,7 @@ class CouponCodeTest extends TestBase {
 
       "generates correct number of codes" in {
         val codePrefix      = "RAND"
-        val desiredQuantity = Random.nextInt(1000)
+        val desiredQuantity = 1 + Random.nextInt(1000 - 1)
         val result          = CouponCodes.generateCodes(codePrefix, 10, desiredQuantity)
 
         result.length must === (desiredQuantity)


### PR DESCRIPTION
I’ve just gotten:

```
[info] CouponCodes
[info]   .generateCodes
[info]   - generates correct number of codes *** FAILED *** (23 milliseconds)
[info]     java.lang.IllegalArgumentException: requirement failed
```