### PR TITLE
Fix hyperion seeder image

### DIFF
--- a/hyperion/Dockerfile.seed
+++ b/hyperion/Dockerfile.seed
@@ -6,20 +6,22 @@ RUN mkdir -p /hyperion
 WORKDIR /hyperion
 COPY . /hyperion
 
-RUN mix local.hex --force
-RUN mix local.rebar --force
-RUN mix deps.get --only prod
-RUN MIX_ENV=prod mix compile
-
 ARG db_host="localhost"
 ARG db_name="hyperion_development"
 ARG db_user="hyperion"
 ARG db_password=""
+ARG hyperion_env=prod
 
 ENV HYPERION_DB_NAME $db_name
 ENV HYPERION_DB_USER $db_user
 ENV HYPERION_DB_PASSWORD $db_password
 ENV HYPERION_DB_HOST $db_host
+ENV MIX_ENV $hyperion_env
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix deps.get --only $hyperion_env
+RUN MIX_ENV=$hyperion_env mix compile
 
 # seeds
 CMD ["./priv/seeds/seed_db.sh"]

--- a/hyperion/priv/seeds/seed_db.sh
+++ b/hyperion/priv/seeds/seed_db.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-
 mix run priv/seeds/clothes_accessories_categories.exs
 mix run priv/seeds/clothes_schema.exs

--- a/tabernacle/ansible/group_vars/all
+++ b/tabernacle/ansible/group_vars/all
@@ -364,4 +364,4 @@ with_shipstation: false
 with_base_seeds: true
 with_gatling_seeder: false
 with_mwh_seeder: true
-with_hyperion_seeder: false
+with_hyperion_seeder: true


### PR DESCRIPTION
Fixes exsync error for prod env

```
"17:46:55.024 [error] ExFSWatch start failed"
"17:46:55.026 [error] backend port not found: inotifywait"
"17:46:55.034 [info]  Application exsync exited: exited in: ExSync.start(:normal, [])"
"    ** (EXIT) exited in: GenServer.call(ExFSWatch.Supervisor, {:start_child, [ExSync.SrcMonitor]}, :infinity)"
"        ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started"
"=INFO REPORT==== 7-Mar-2017::17:46:55 ==="
"    application: logger"
"    exited: stopped"
"    type: temporary"
"17:46:56.251 [error] ExFSWatch start failed"
"17:46:56.252 [error] backend port not found: inotifywait"
```