### PR TITLE
Upgrade Docker to 1.13 in base images

### DIFF
--- a/engineering-wiki/devops/Development-Kit.md
+++ b/engineering-wiki/devops/Development-Kit.md
@@ -74,7 +74,6 @@ Various package management and build systems which are necessary for modern deve
 Baked in command-line utilities which ease problem solving:
 
 * [consulate](https://github.com/gmr/consulate) - command-line client for the Consul HTTP API.
-* [docker-clean](https://github.com/ZZROTDesign/docker-clean) - a simple shell script to clean up the Docker Daemon.
 * [docker-compose](https://github.com/docker/compose) - define and run multi-container applications with Docker.
 * [flyway](https://flywaydb.org) - open-source database migration tool.
 * [httpie](https://httpie.org) - a command line HTTP client that will make you smile.

--- a/tabernacle/README.md
+++ b/tabernacle/README.md
@@ -8,7 +8,7 @@ All of our DevOps tools for deploying the application to both development and pr
 
 - [Ansible](https://ansible.com) 2.2.x
 - [AWS CLI](https://aws.amazon.com/cli)
-- [Docker](https://docker.com) 1.12 or above
+- [Docker](https://docker.com) 1.13
 - [Go](https://golang.org) 1.6 or above
 - [Google Cloud SDK](https://cloud.google.com/sdk/gcloud)
 - [Packer](https://packer.io)

--- a/tabernacle/ansible/roles/base/common/tasks/docker.yml
+++ b/tabernacle/ansible/roles/base/common/tasks/docker.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Add Docker Key
-  apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80 id=58118E89F3A912897C070ADBF76221572C52609D
+  apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
 
 - name: Add Docker Repository
-  apt_repository: repo="deb https://apt.dockerproject.org/repo ubuntu-xenial main" state=present update_cache=yes
+  apt_repository: repo="deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" state=present update_cache=yes
 
 - name: Install Docker-Compose Dependency
   pip: name=ipaddress
@@ -12,7 +12,7 @@
 - name: Install Docker
   apt: name={{item}} state=latest force=yes
   with_items:
-    - docker-engine
+    - docker-ce
     - docker-compose
 
 - name: Add User to Docker Group

--- a/tabernacle/ansible/roles/base/common/tasks/main.yml
+++ b/tabernacle/ansible/roles/base/common/tasks/main.yml
@@ -15,6 +15,8 @@
 - name: Install Core Packages
   apt: name={{item}} state=latest force=yes
   with_items:
+    - apt-transport-https
+    - ca-certificates
     - debconf-utils
     - curl
     - htop

--- a/tabernacle/ansible/roles/base/devkit/files/docker-clean.sh
+++ b/tabernacle/ansible/roles/base/devkit/files/docker-clean.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-clean
+docker system prune --force

--- a/tabernacle/ansible/roles/base/devkit/tasks/main.yml
+++ b/tabernacle/ansible/roles/base/devkit/tasks/main.yml
@@ -20,8 +20,5 @@
 - name: Install kt
   unarchive: src={{kt_download_url}} dest=/usr/local/bin/ remote_src=yes mode=0755
 
-- name: Download docker-clean Installer
-  get_url: url={{docker_clean_url}} dest=/usr/local/bin/docker-clean mode=0755
-
-- name: Install Docker Clean to cron.hourly
+- name: Install Docker clean script to cron.hourly
   copy: src=docker-clean.sh dest=/etc/cron.hourly/dockerclean mode=0755


### PR DESCRIPTION
https://store.docker.com/editions/community/docker-ce-server-ubuntu?tab=description

Also use `docker system prune` to cleanup dangling images instead of `docker-clean`

Buildkite agents are manually upgraded via `csshx`