### PR TITLE
Bugfix: use variantId instead of id when picking variants

### DIFF
--- a/ashes/src/components/carts/line-items-footer.jsx
+++ b/ashes/src/components/carts/line-items-footer.jsx
@@ -48,13 +48,13 @@ export class CartLineItemsFooter extends Component {
     const { cart: { referenceNumber }, updateLineItemCount } = this.props;
 
     const skus = _.get(this.props, 'cart.lineItems.skus', []);
-    const matched = _.find(skus, { productVariantId: item.id });
+    const matched = _.find(skus, { productVariantId: item.variantId });
 
     if (!_.isEmpty(matched)) {
       return;
     }
 
-    updateLineItemCount(referenceNumber, item.id, 1);
+    updateLineItemCount(referenceNumber, item.variantId, 1);
   }
 
   @autobind


### PR DESCRIPTION
`id` is a search view entry id, and since variants' ids are actually
form ids, `id` and `variantId` are not equivalent