### PR TITLE
Set test environment for local seeder run

### DIFF
--- a/phoenix-scala/build.sbt
+++ b/phoenix-scala/build.sbt
@@ -87,6 +87,8 @@ lazy val seeder = (project in file("seeder"))
     scalafmtConfig := Some(file(".scalafmt")),
     reformatOnCompileSettings, // scalafmt,
     Revolver.settings,
+    // we cannot fork and set javaOptions simply, as it causes some weird issue with db schema creation
+    initialize ~= (_ => System.setProperty("phoenix.env", "test" )),
     assemblyMergeStrategy in assembly := {
       case PathList("org", "joda", "time", xs @ _ *) ⇒
         MergeStrategy.first

--- a/phoenix-scala/resources/stub.conf
+++ b/phoenix-scala/resources/stub.conf
@@ -11,6 +11,11 @@ apis {
   middlewarehouse.url = ""
 
   stripe.key = ""
+
+  kafka {
+    schemaRegistryURL = ""
+    bootStrapServersConfig = ""
+  }
 }
 
 auth {

--- a/phoenix-scala/resources/test.conf
+++ b/phoenix-scala/resources/test.conf
@@ -15,13 +15,3 @@ db.name = "phoenix_test"
 
 taxRules.regionId = "4129" # California
 taxRules.rate = "7.5"
-
-apis {
-  kafka {
-    schemaRegistryURL = "dummy"
-    bootStrapServersConfig = "dummy"
-    producerTimeout = "250"
-    keySerializer = "io.confluent.kafka.serializers.KafkaAvroSerializer"
-    valueSerializer = "io.confluent.kafka.serializers.KafkaAvroSerializer"
-  }
-}


### PR DESCRIPTION
So one would not need to set `PHOENIX_ENV` by hand on local machine.