### PR TITLE
Logrotate syslog by 100M, not daily

### DIFF
--- a/tabernacle/ansible/roles/hotfix/rsyslog/tasks/main.yml
+++ b/tabernacle/ansible/roles/hotfix/rsyslog/tasks/main.yml
@@ -11,5 +11,8 @@
     group=root
     mode=0644
 
+- name: Update Syslog Rotation
+  lineinfile: dest="{{logrotate_dir}}/rsyslog" regexp='^daily' line='size=100M'
+
 - name: Restart Rsyslog
   service: name=rsyslog state=restarted enabled=yes


### PR DESCRIPTION
```
ejik@promos:~$ cat /etc/logrotate.d/rsyslog
/var/log/syslog
{
	rotate 7
	daily
	missingok
	notifempty
	delaycompress
	compress
	postrotate
		invoke-rc.d rsyslog rotate > /dev/null
	endscript
}

/var/log/mail.info
/var/log/mail.warn
/var/log/mail.err
/var/log/mail.log
/var/log/daemon.log
/var/log/kern.log
/var/log/auth.log
/var/log/user.log
/var/log/lpr.log
/var/log/cron.log
/var/log/debug
/var/log/messages
{
	rotate 4
	weekly
	missingok
	notifempty
	compress
	delaycompress
	sharedscripts
	postrotate
		invoke-rc.d rsyslog rotate > /dev/null
	endscript
}
```