### PR TITLE
Fix empty scope in seeds.

### DIFF
--- a/green-river/src/main/scala/consumer/elastic/ScopedIndexer.scala
+++ b/green-river/src/main/scala/consumer/elastic/ScopedIndexer.scala
@@ -89,9 +89,16 @@ class ScopedIndexer(uri: String,
   private def indexScopes(
       scopes: Seq[String], documentId: BigInt, document: String, topic: String): Future[Unit] = {
     Future
-      .sequence(scopes.map { scope ⇒
-        val scopedIndexName = s"${indexName}_${scope}"
-        indexDocument(scopedIndexName, documentId, document, topic)
+      .sequence(
+          scopes.map { scope ⇒
+        if (!scope.isEmpty()) {
+          val scopedIndexName = s"${indexName}_${scope}"
+          indexDocument(scopedIndexName, documentId, document, topic)
+        } else {
+          Console.out.println(
+              s"Skipping document with empty scope on topic $topic...\r\n$document")
+          Future { () }
+        }
       })
       .map(_ ⇒ ())
   }

--- a/phoenix-scala/seeder/src/main/scala/utils/seeds/Seeds.scala
+++ b/phoenix-scala/seeder/src/main/scala/utils/seeds/Seeds.scala
@@ -122,7 +122,7 @@ object Seeds {
     val config: Config           = FoxConfig.unsafe
     implicit val db: DatabaseDef = Database.forConfig("db", config)
     implicit val ac: AC = ActivityContext
-      .build(userId = 1, userType = "user", scope = LTree(""), transactionId = "seeds")
+      .build(userId = 1, userType = "user", scope = LTree("1"), transactionId = "seeds")
 
     cfg.mode match {
       case Seed ⇒


### PR DESCRIPTION
Also allow green river to skip documents with empty scopes.