### PR TITLE
Add outOfOrder flag to flyway configuration

### DIFF
--- a/tabernacle/ansible/roles/prod/migrate_phoenix_db/templates/flyway.conf.j2
+++ b/tabernacle/ansible/roles/prod/migrate_phoenix_db/templates/flyway.conf.j2
@@ -2,3 +2,4 @@ flyway.url=jdbc:postgresql://localhost/{{phoenix_db_name}}?user={{phoenix_db_use
 flyway.user={{phoenix_db_user}}
 flyway.password=
 flyway.schemas=public
+flyway.outOfOrder=true


### PR DESCRIPTION
Lack of this flag in flyway config for feature branches makes updating them quite clumsy.
Manual intervention (specifying this flag manually and running flyway migration then) is required whenever any new versioned migration was added to master, as on feature branches we usually start with some higher version in order to minimize collisions (e.g. as in `returns` branch).