### PR TITLE
Fix product image scaling on calalog when window resizes.

### DIFF
--- a/demo/peacock/src/components/image/image.css
+++ b/demo/peacock/src/components/image/image.css
@@ -1,0 +1,5 @@
+
+img {
+  width: auto;
+  height: auto;
+}

--- a/demo/peacock/src/components/image/image.jsx
+++ b/demo/peacock/src/components/image/image.jsx
@@ -3,6 +3,7 @@
 import React, { Component } from 'react';
 import { env } from 'lib/env';
 import ProductImage from '@foxcomm/wings/lib/ui/imgix/product-image';
+import styles from './image.css';
 
 type Props = {
   src: string,


### PR DESCRIPTION
After moving to wings product image component the resize caused issues.
This fixes the aspect ratio for product images.