### PR TITLE
Remove calls to deprecated stuff in build.sbt (and the warnings)

### DIFF
--- a/phoenix-scala/build.sbt
+++ b/phoenix-scala/build.sbt
@@ -31,19 +31,19 @@ lazy val phoenixScala = (project in file("."))
       akka ++ http ++ auth ++ db ++ slick ++ json4s ++ fasterxml ++ apis ++ logging ++ test ++ misc ++ kafka
     },
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3"),
-    scalaSource in Compile <<= baseDirectory(_ / "app"),
-    scalaSource in Test    <<= baseDirectory(_ / "test" / "unit"),
-    scalaSource in IT      <<= baseDirectory(_ / "test" / "integration"),
-    scalaSource in ET      <<= baseDirectory(_ / "test" / "integration"),
-    resourceDirectory in Compile <<= baseDirectory(_ / "resources"),
-    resourceDirectory in Test    <<= baseDirectory(_ / "test" / "resources"),
-    resourceDirectory in IT      <<= resourceDirectory in Test,
-    resourceDirectory in ET      <<= resourceDirectory in Test,
+    scalaSource in Compile := baseDirectory.value / "app",
+    scalaSource in Test    := baseDirectory.value / "test" / "unit",
+    scalaSource in IT      := baseDirectory.value / "test" / "integration",
+    scalaSource in ET      := baseDirectory.value / "test" / "integration",
+    resourceDirectory in Compile := baseDirectory.value / "resources",
+    resourceDirectory in Test    := baseDirectory.value / "test" / "resources",
+    resourceDirectory in IT      := (resourceDirectory in Test).value,
+    resourceDirectory in ET      := (resourceDirectory in Test).value,
     Revolver.settings,
     (mainClass in Compile) := Some("server.Main"),
     initialCommands in console := fromFile("project/console_init").getLines.mkString("\n"),
     initialCommands in (Compile, consoleQuick) := "",
-    writeVersion <<= sh.toTask(fromFile("project/write_version").getLines.mkString),
+    writeVersion := sh.toTask(fromFile("project/write_version").getLines.mkString).value,
     unmanagedResources in Compile += file("version"),
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     javaOptions in Test ++= Seq("-Xmx2G", "-XX:+UseConcMarkSweepGC", "-Dphoenix.env=test"),
@@ -83,7 +83,7 @@ lazy val seeder = (project in file("seeder"))
   .settings(
     commonSettings,
     libraryDependencies ++= Dependencies.gatling,
-    cleanFiles <+= baseDirectory(_ / "results"),
+    cleanFiles += baseDirectory.value / "results",
     scalafmtConfig := Some(file(".scalafmt")),
     reformatOnCompileSettings, // scalafmt,
     Revolver.settings,
@@ -110,7 +110,7 @@ lazy val seeder = (project in file("seeder"))
     assemblyExcludedJars in assembly := (fullClasspath in assembly in phoenixScala).value
   )
 
-fullAssembly <<= Def.task().dependsOn(writeVersion in phoenixScala, assembly in phoenixScala, assembly in seeder)
+fullAssembly := Def.task().dependsOn(writeVersion in phoenixScala, assembly in phoenixScala, assembly in seeder).value
 
 // Injected seeds
 val seedCommand = " utils.seeds.Seeds seed --seedAdmins"
@@ -122,18 +122,18 @@ seedOneshot    := (runMain in Compile in seeder).partialInput(" gatling.seeds.On
 seedContinuous := (runMain in Compile in seeder).partialInput(" gatling.seeds.ContinuousSeeds").evaluated
 
 // Scalafmt
-scalafmtAll <<= Def.task().dependsOn(scalafmt in Compile in phoenixScala,
+scalafmtAll := Def.task().dependsOn(scalafmt in Compile in phoenixScala,
                                      scalafmt in Test    in phoenixScala,
                                      scalafmt in IT      in phoenixScala,
                                      scalafmt in ET      in phoenixScala,
-                                     scalafmt in Compile in seeder)
+                                     scalafmt in Compile in seeder).value
 
-scalafmtTestAll <<= Def.task().dependsOn(scalafmtTest in Compile in phoenixScala,
+scalafmtTestAll := Def.task().dependsOn(scalafmtTest in Compile in phoenixScala,
                                          scalafmtTest in Test    in phoenixScala,
                                          scalafmtTest in IT      in phoenixScala,
                                          scalafmtTest in ET      in phoenixScala,
-                                         scalafmtTest in Compile in seeder)
+                                         scalafmtTest in Compile in seeder).value
 
 // Test
-test <<= Def.sequential(compile in Test, compile in IT, compile in ET,
-                        test    in Test, test    in IT, test    in ET)
+test := Def.sequential(compile in Test, compile in IT, compile in ET,
+                        test    in Test, test    in IT, test    in ET).value


### PR DESCRIPTION
Why isn’t build.sbt autoformatted?