### PR TITLE
Remove manual validate calls for payloads

### DIFF
--- a/phoenix-scala/app/payloads/PaymentPayloads.scala
+++ b/phoenix-scala/app/payloads/PaymentPayloads.scala
@@ -18,7 +18,8 @@ object PaymentPayloads {
                                               brand: String,
                                               holderName: String,
                                               billingAddress: CreateAddressPayload,
-                                              addressIsNew: Boolean) {
+                                              addressIsNew: Boolean)
+      extends Validation[CreateCreditCardFromTokenPayload] {
     def validate: ValidatedNel[Failure, CreateCreditCardFromTokenPayload] = {
       import Validation._
 
@@ -45,7 +46,8 @@ object PaymentPayloads {
                                                address: Option[CreateAddressPayload] = None,
                                                addressId: Option[Int] = None,
                                                isDefault: Boolean = false,
-                                               isShipping: Boolean = false) {
+                                               isShipping: Boolean = false)
+      extends Validation[CreateCreditCardFromSourcePayload] {
 
     def validate: ValidatedNel[Failure, CreateCreditCardFromSourcePayload] = {
       import Validation._
@@ -76,7 +78,8 @@ object PaymentPayloads {
                             expMonth: Option[Int] = None,
                             addressId: Option[Int] = None,
                             address: Option[CreateAddressPayload] = None,
-                            isShipping: Boolean = false) {
+                            isShipping: Boolean = false)
+      extends Validation[EditCreditCard] {
 
     def validate: ValidatedNel[Failure, EditCreditCard] = {
       import Validation._

--- a/phoenix-scala/app/services/CreditCardManager.scala
+++ b/phoenix-scala/app/services/CreditCardManager.scala
@@ -38,7 +38,6 @@ object CreditCardManager {
       payload: CreateCreditCardFromTokenPayload,
       admin: Option[User] = None)(implicit ec: EC, db: DB, apis: Apis, ac: AC): DbResultT[Root] = {
     for {
-      _        ← * <~ payload.validate
       _        ← * <~ Regions.mustFindById400(payload.billingAddress.regionId)
       customer ← * <~ Users.mustFindByAccountId(accountId)
       customerToken ← * <~ CreditCards
@@ -94,7 +93,6 @@ object CreditCardManager {
       } yield (stripeId, address)
 
     for {
-      _                  ← * <~ payload.validate
       customer           ← * <~ Users.mustFindByAccountId(accountId)
       stripeIdAndAddress ← * <~ getExistingStripeIdAndAddress
       (stripeId, address) = stripeIdAndAddress
@@ -190,7 +188,6 @@ object CreditCardManager {
     } yield address.fold(creditCard)(creditCard.copyFromAddress)
 
     for {
-      _           ← * <~ payload.validate
       customer    ← * <~ Users.mustFindByAccountId(accountId)
       creditCard  ← * <~ getCardAndAddressChange
       updated     ← * <~ update(customer, creditCard)

--- a/phoenix-scala/app/services/StoreCreditService.scala
+++ b/phoenix-scala/app/services/StoreCreditService.scala
@@ -127,7 +127,6 @@ object StoreCreditService {
       payload: StoreCreditBulkUpdateStateByCsr,
       admin: User)(implicit ec: EC, db: DB, ac: AC): DbResultT[List[ItemResult]] =
     for {
-      _ ← * <~ payload.validate.toXor
       response ← * <~ DbResultT.seqCollectFailures(payload.ids.map { id ⇒
                   val itemPayload = StoreCreditUpdateStateByCsr(payload.state, payload.reasonId)
                   updateStateByCsr(id, itemPayload, admin)
@@ -139,7 +138,6 @@ object StoreCreditService {
                        payload: StoreCreditUpdateStateByCsr,
                        admin: User)(implicit ec: EC, db: DB, ac: AC): DbResultT[Root] =
     for {
-      _           ← * <~ payload.validate
       storeCredit ← * <~ StoreCredits.mustFindById404(id)
       updated     ← * <~ cancelOrUpdate(storeCredit, payload.state, payload.reasonId, admin)
       _           ← * <~ LogActivity().scUpdated(admin, storeCredit, payload)

--- a/phoenix-scala/app/services/customers/CustomerManager.scala
+++ b/phoenix-scala/app/services/customers/CustomerManager.scala
@@ -181,7 +181,6 @@ object CustomerManager {
                                                          db: DB,
                                                          ac: AC): DbResultT[(User, CustomerData)] =
     for {
-      _        ← * <~ payload.validate
       customer ← * <~ Users.mustFindByAccountId(accountId)
       custData ← * <~ CustomersData.mustFindByAccountId(accountId)
       _ ← * <~ (if (custData.isGuest) DbResultT.unit
@@ -195,7 +194,6 @@ object CustomerManager {
       accountId: Int,
       payload: ChangeCustomerPasswordPayload)(implicit ec: EC, db: DB, ac: AC): DbResultT[Unit] =
     for {
-      _       ← * <~ payload.validate
       user    ← * <~ Users.mustFindByAccountId(accountId)
       account ← * <~ Accounts.mustFindById404(accountId)
       accessMethod ← * <~ AccountAccessMethods
@@ -226,7 +224,6 @@ object CustomerManager {
                payload: ActivateCustomerPayload,
                admin: User)(implicit ec: EC, db: DB, ac: AC): DbResultT[Root] =
     for {
-      _        ← * <~ payload.validate
       customer ← * <~ Users.mustFindByAccountId(accountId)
       _ ← * <~ (customer.email match {
                case None ⇒ DbResultT.failure(CustomerMustHaveCredentials)

--- a/phoenix-scala/app/services/image/ImageManager.scala
+++ b/phoenix-scala/app/services/image/ImageManager.scala
@@ -89,14 +89,12 @@ object ImageManager {
     } yield AlbumResponse.build(album, images)
 
   def createAlbumInner(
-      createPayload: AlbumPayload,
+      payload: AlbumPayload,
       context: ObjectContext)(implicit ec: EC, db: DB, au: AU): DbResultT[FullAlbumWithImages] =
     for {
-      payload ← * <~ createPayload.validate
-
       album ← * <~ ObjectUtils.insertFullObject(
                  payload.formAndShadow,
-                 ins ⇒ createAlbumHeadFromInsert(context, ins, createPayload.scope))
+                 ins ⇒ createAlbumHeadFromInsert(context, ins, payload.scope))
       images ← * <~ (payload.images match {
                     case Some(imagesPayload) ⇒
                       createImagesForAlbum(album.model, imagesPayload, context)
@@ -213,13 +211,12 @@ object ImageManager {
       response ← * <~ updateAlbumInner(id, payload, context)
     } yield AlbumResponse.build(response)
 
-  def updateAlbumInner(id: ObjectForm#Id, updatePayload: AlbumPayload, context: ObjectContext)(
+  def updateAlbumInner(id: ObjectForm#Id, payload: AlbumPayload, context: ObjectContext)(
       implicit ec: EC,
       db: DB,
       au: AU): DbResultT[FullAlbumWithImages] =
     for {
-      payload ← * <~ updatePayload.validate
-      album   ← * <~ mustFindFullAlbumByFormIdAndContext404(id, context)
+      album ← * <~ mustFindFullAlbumByFormIdAndContext404(id, context)
       oldShadow                    = album.shadow
       (payloadForm, payloadShadow) = payload.formAndShadow.tupled
       mergedAtts                   = oldShadow.attributes.merge(payloadShadow.attributes)

--- a/phoenix-scala/app/services/taxonomy/TaxonomyManager.scala
+++ b/phoenix-scala/app/services/taxonomy/TaxonomyManager.scala
@@ -123,7 +123,6 @@ object TaxonomyManager {
     val shadow = ObjectShadow.fromPayload(payload.attributes)
 
     for {
-      _        ← * <~ payload.validate
       scope    ← * <~ Scope.resolveOverride(payload.scope)
       taxonomy ← * <~ Taxonomies.mustFindByFormId404(taxonomyFormId)
 
@@ -181,7 +180,6 @@ object TaxonomyManager {
       oc: OC,
       db: DB): DbResultT[FullTaxonResponse] = {
     for {
-      _        ← * <~ payload.validate
       taxon    ← * <~ Taxons.mustFindByFormId404(taxonId)
       _        ← * <~ failIf(taxon.archivedAt.isDefined, TaxonIsArchived(taxonId))
       newTaxon ← * <~ updateTaxonAttributes(taxon, payload)

--- a/phoenix-scala/app/utils/Validation.scala
+++ b/phoenix-scala/app/utils/Validation.scala
@@ -1,15 +1,13 @@
 package utils
 
-import java.time.LocalDateTime
-
-import scala.util.matching.Regex
-
 import cats.data.Validated.{Invalid, Valid, invalidNel, valid}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import com.wix.accord
 import com.wix.accord.RuleViolation
 import com.wix.accord.combinators._
 import failures.{Failure, GeneralFailure}
+import java.time.LocalDateTime
+import scala.util.matching.Regex
 
 trait Validation[M] {
   def validate: ValidatedNel[Failure, M]

--- a/phoenix-scala/app/utils/http/JsonSupport.scala
+++ b/phoenix-scala/app/utils/http/JsonSupport.scala
@@ -12,7 +12,7 @@ case class FoxValidationException(failures: Failures) extends Exception
 
 object JsonSupport extends Json4sSupport {
   private def validateData[A <: Validation[_]](data: A): Future[A] = data.validate match {
-    case Valid(v)          ⇒ Future.successful(data)
+    case Valid(_)          ⇒ Future.successful(data)
     case Invalid(failures) ⇒ Future.failed(FoxValidationException(failures))
   }
 


### PR DESCRIPTION
There are not necessary now, as `.validate` on payloads is called automatically on their unmarshalling from JSON.