### PR TITLE
Reduce one level in checker response

### DIFF
--- a/hyperion/lib/hyperion/workers/amazon/push_checker_worker.ex
+++ b/hyperion/lib/hyperion/workers/amazon/push_checker_worker.ex
@@ -52,7 +52,7 @@ defmodule Hyperion.Amazon.Workers.PushCheckerWorker do
       {:error, error} -> Logger.error "Push ID: #{push.id} checking error: #{inspect(error)}"
       {_, resp} ->
         feed_result_name = String.to_atom("#{Atom.to_string(feed_name)}_result")
-        data = %{feed_result_name => resp["AmazonEnvelope"]["Message"]["ProcessingReport"]}
+        data = resp["AmazonEnvelope"]["Message"]["ProcessingReport"]
         store_result(push.id, feed_result_name, data)
     end
   end
@@ -62,7 +62,7 @@ defmodule Hyperion.Amazon.Workers.PushCheckerWorker do
     row = Ecto.Changeset.change(row, %{feed_result_name => result})
     case Hyperion.Repo.update(row) do
       {:ok, struct} ->
-        Logger.info("#{push_id} #{inspect(result)}")
+        Logger.info("Push ID: #{push_id}. #{feed_result_name}: #{inspect(result)}")
         mark_as_complete(struct)
       {:error, changeset} -> Logger.error("#{push_id}: Error while updating push with results: #{inspect(changeset)}")
     end

--- a/hyperion/spec/lib/workers/push_checker_worker_spec.exs
+++ b/hyperion/spec/lib/workers/push_checker_worker_spec.exs
@@ -9,12 +9,16 @@ defmodule PushCheckerWorkerSpec do
                 images_feed: %{"FeedSubmissionId" => "123"},
                 variations_feed: %{"FeedSubmissionId" => "123"}}
     let pushes: build(:submission_result, attrs)
-    let amazon_resp: {:ok, %{"AmazonEnvelope" => %{"Message" => %{"ProcessingReport" => %{"Foo" => "Bar"}}}}}
 
     before do
       Hyperion.Repo.insert!(pushes)
       allow(Hyperion.Amazon).to accept(:fetch_config, fn() -> %MWSClient.Config{} end)
-      allow(MWSClient).to accept(:get_feed_submission_result, fn(_, _) -> amazon_resp() end)
+      allow(MWSClient).to accept(:get_feed_submission_result, fn(_, _) ->
+        {:ok, %{"AmazonEnvelope" =>
+                %{"Message" =>
+                  %{"ProcessingReport" =>
+                    %{"Foo" => :crypto.strong_rand_bytes(32) |> Base.encode64}}}}}
+      end)
     end
 
     it "should check push" do


### PR DESCRIPTION
Making this:
```json
"product_feed_result": {
        "product_feed_result": {
            "StatusCode": "Complete",
            "ProcessingSummary": {
                "MessagesWithWarning": "0",
                "MessagesWithError": "0",
                "MessagesSuccessful": "2",
                "MessagesProcessed": "2"
            },
            "DocumentTransactionID": "50790017259"
        }
    },
```

looking like:

```json
        "product_feed_result": {
            "StatusCode": "Complete",
            "ProcessingSummary": {
                "MessagesWithWarning": "0",
                "MessagesWithError": "0",
                "MessagesSuccessful": "2",
                "MessagesProcessed": "2"
            },
            "DocumentTransactionID": "50790017259"
        },
```