### PR TITLE
Health check for hyperion was hardcoded at 8880

### DIFF
--- a/tabernacle/ansible/roles/dev/marathon/templates/hyperion.json
+++ b/tabernacle/ansible/roles/dev/marathon/templates/hyperion.json
@@ -27,7 +27,6 @@
     "PUBLIC_KEY": "{{public_keys_dest_dir}}/public_key.pem",
     "PUSH_CHECK_INTERVAL": "{{hyperion_push_check_interval}}"
   },
-  "ports": [{{hyperion_port}}],
   "constraints": [["hostname", "UNIQUE"]],
   "container": {
     "type": "DOCKER",
@@ -60,7 +59,7 @@
       "timeoutSeconds": 20,
       "maxConsecutiveFailures": 3,
       "ignoreHttp1xx": false,
-      "port": {{hyperion_port}}
+      "portIndex": 0
     }
   ]
 }


### PR DESCRIPTION
Hyperion uses a port assigned by Marathon, so the health check on 8880 broke the deployment.