### PR TITLE
Make seeding optional

### DIFF
--- a/tabernacle/ansible/goldrush_appliance.yml
+++ b/tabernacle/ansible/goldrush_appliance.yml
@@ -53,7 +53,7 @@
     - { role: dev/db }
     - { role: dev/db_ic, when: with_ic }
     # Marathon
-    - { role: dev/seed_system }
+    - { role: dev/seed_system, when: with_appliance_seeding }
     - { role: dev/marathon }
     - { role: hotfix/replace_mesos_consul }
     - { role: base/marathon_consul }
@@ -66,7 +66,7 @@
     - { role: hotfix/replace_mesos_consul, stop_mesos_consul: true }
     - { role: demo/balancer }
     # Seed
-    - { role: dev/seeder }
+    - { role: dev/seeder, when: with_appliance_seeding }
     # Finale
     - { role: dev/healthcheck }
     - { role: dev/appliance_dns }

--- a/tabernacle/ansible/group_vars/all
+++ b/tabernacle/ansible/group_vars/all
@@ -104,6 +104,9 @@ marathon_restart:
 # Should we use Intelligent Commerce
 with_ic: "{{ lookup('env', 'WITH_INTELLIGENT_COMMERCE') | default(true, true) | bool }}"
 
+# Should we do seeding for appliance
+with_appliance_seeding: "{{ lookup('env', 'WITH_APPLIANCE_SEEDING') | default(true, true) | bool }}"
+
 # Consul Service Discovery
 consul_data_dir: /var/consul
 consul_suffix: service.consul

--- a/tabernacle/ansible/roles/dev/goldrush_cfg/templates/goldrush.cfg.j2
+++ b/tabernacle/ansible/roles/dev/goldrush_cfg/templates/goldrush.cfg.j2
@@ -10,6 +10,9 @@ export GOOGLE_INSTANCE_NAME={{google_instance_name}}
 # Should we include IC?
 export WITH_INTELLIGENT_COMMERCE={{with_ic_value}}
 
+# Should we seed?
+export WITH_APPLIANCE_SEEDING=true
+
 ####################################################################
 # Docker Tags                                                      #
 ####################################################################


### PR DESCRIPTION
This is a springboard for making seeding asynchronous + improving appliance pipeline speed. We can split the testing of a) instance provisioning and b) running seeding containers, because it's different layers of system (devops vs development).