### PR TITLE
Fix dev appliance pipeline, attempt №2

### DIFF
--- a/tabernacle/ansible/goldrush_appliance.yml
+++ b/tabernacle/ansible/goldrush_appliance.yml
@@ -50,20 +50,19 @@
     - { role: hotfix/elasticsearch }
     - { role: hotfix/rsyslog }
     - { role: hotfix/kibana }
+    - { role: hotfix/replace_mesos_consul }
+    - { role: hotfix/marathon_consul }
     - { role: dev/db }
     - { role: dev/db_ic, when: with_ic }
     # Marathon
     - { role: dev/seed_system }
     - { role: dev/marathon }
-    - { role: hotfix/replace_mesos_consul }
-    - { role: hotfix/marathon_consul }
     - { role: dev/marathon_consumers }
     - { role: dev/ic }
     - { role: ext/td/storefront }
     - { role: ext/tpg/storefront }
     # Nginx
     - { role: dev/balancer }
-    - { role: hotfix/replace_mesos_consul, stop_mesos_consul: true }
     - { role: demo/balancer }
     # Seed
     - { role: dev/seeder, when: with_appliance_seeding }

--- a/tabernacle/ansible/roles/hotfix/marathon_consul/tasks/main.yml
+++ b/tabernacle/ansible/roles/hotfix/marathon_consul/tasks/main.yml
@@ -1,32 +1,25 @@
 ---
 
-- name: Add Marathon consul apt key
+- name: Add Marathon Consul APT key
   apt_key: url={{marathon_consul_apt_key_url}}
 
-- name: Add Marathon consul repository
+- name: Add Marathon Consul repository
   apt_repository: repo='deb {{marathon_consul_apt_url}} /' state=present update_cache=yes
 
-- name: Install marathon-consul
+- name: Install Marathon Consul
   apt: name=marathon-consul state=latest force=yes
 
-- name: Install marathon consul config
+- name: Install Marathon Consul config
   template: src=config.json dest={{marathon_consul_config_path}}
 
-- name: Start marathon-consul
-  systemd:
-    state: restarted
-    enabled: yes
-    daemon_reload: yes
-    name: marathon-consul
+- name: Start Marathon Consul
+  systemd: state=restarted enabled=yes daemon_reload=yes name=marathon-consul
 
 - name: Copy Consul Service File
   template: src=marathon-consul.json dest="/etc/consul.d/marathon-consul.json"
 
-- name: Restart Consul Agent
-  systemd: name=consul_agent state=restarted
-
-- name: Ensure Marathon is available
-  wait_for: host={{marathon_host}} port={{marathon_port}}
+- name: Reload Consul Configuration
+  shell: consul reload
 
 - name: Wait before marathon-consul.service.consul will be registered
   shell: 'ping -c 1 marathon-consul.service.consul'
@@ -35,5 +28,5 @@
   retries: "{{marathon_retries}}"
   delay: 2
 
-- name: Subscribe marathon events to marathon-consul
+- name: Subscribe Marathon events to Marathon Consul
   command: curl -X POST 'http://marathon.service.consul:8080/v2/eventSubscriptions?callbackUrl=http://marathon-consul.service.consul:4000/events'

--- a/tabernacle/ansible/roles/hotfix/replace_mesos_consul/tasks/main.yml
+++ b/tabernacle/ansible/roles/hotfix/replace_mesos_consul/tasks/main.yml
@@ -1,21 +1,13 @@
 ---
 
 - name: Disable Mesos Consul
-  systemd:
-    state: stopped
-    enabled: no
-    daemon_reload: yes
-    name: mesos_consul
-  when: stop_mesos_consul is defined and stop_mesos_consul
+  systemd: state=stopped enabled=no daemon_reload=yes name=mesos_consul
 
 - name: Remove "marathon" tag in Consul for Marathon
   template: src=marathon.json dest=/etc/consul.d/marathon.json
 
 - name: Remove Mesos Consul service from Consul
   file: path=/etc/consul.d/mesos_consul.json state=absent
-
-- name: Restart Consul Agent
-  systemd: name=consul_agent state=restarted
 
 - name: Include vars from Mesos Master role
   include_vars: "{{role_path}}/../../base/mesos_master/vars/main.yml"


### PR DESCRIPTION
Cont. #1405

Problem - Marathon crashed after Consul Agent was restarted, was unable to find Zookeeper during hardcore config reload pause. Hope `consul reload` trigger is more graceful

```
Apr 13 13:02:54 appliance-buildkite-agent marathon[16653]: [2017-04-13 13:02:54,876] WARN  No IP address found for server: zookeeper.service.consul:2181 (org.apache.zookeeper.client.StaticHostProvider:main)
Apr 13 13:02:54 appliance-buildkite-agent marathon[16653]: java.net.UnknownHostException: zookeeper.service.consul: Name or service not known

Apr 13 13:02:54 appliance-buildkite-agent marathon[16653]: [2017-04-13 13:02:54,877] ERROR Background exception was not retry-able or retry gave up (org.apache.curator.framework.imps.CuratorFrameworkImpl:main)
Apr 13 13:02:54 appliance-buildkite-agent marathon[16653]: java.lang.IllegalArgumentException: A HostProvider may not be empty!
```