### PR TITLE
Fix Neo4j healthcheck

### DIFF
--- a/tabernacle/ansible/roles/dev/ic/templates/neo4j.json
+++ b/tabernacle/ansible/roles/dev/ic/templates/neo4j.json
@@ -55,14 +55,13 @@
   ],
   "healthChecks": [
     {
-      "protocol": "COMMAND",
-      "command": {
-        "value": "curl -X GET \"http://{{neo4j_user}}:{{neo4j_pass}}@{{neo4j_host}}:{{neo4j_http_port}}/db/data/\""
-      },
       "gracePeriodSeconds": 300,
-      "intervalSeconds": 60,
+      "intervalSeconds": 30,
       "timeoutSeconds": 20,
       "maxConsecutiveFailures": 3,
+      "port": 7474,
+      "path": "/",
+      "protocol": "HTTP",
       "ignoreHttp1xx": false
     }
   ],


### PR DESCRIPTION
Cont of #1414

Neo4j container wasn't able to perform healthcheck, because it was refering to DNS record which was not propagated by `mesos-consul` / `marathon-consul`, because it was waiting for successful deployment (which wasn't being done because of failing healthcheck in endless loop)

Took an example working healthcheck from here
https://github.com/neo4j-contrib/neo4j-dcos/blob/master/marathon-sample-configuration.json