### PR TITLE
Remove sticky positioning

### DIFF
--- a/demo/peacock/public/css/overrides.css
+++ b/demo/peacock/public/css/overrides.css
@@ -4,9 +4,3 @@ div#app {
   height: 100vh;
   padding-top: 50px;
 }
-
-@supports (position: sticky) or (position: -webkit-sticky) {
-  div#app {
-    padding-top: 0;
-  }
-}

--- a/demo/peacock/src/components/header/header.css
+++ b/demo/peacock/src/components/header/header.css
@@ -22,12 +22,6 @@
   padding: 0;
 }
 
-@supports (position: sticky) {
-  .header-wrap {
-    position: sticky;
-  }
-}
-
 .wrap {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Remove sticky positioning because it isn't supported on a lot of our
supported browsers and it seems to be causing the menu to disappear on
browsers where it is supported.