### PR TITLE
Override coupon attributes with more correct (⸮) ones

### DIFF
--- a/phoenix-scala/app/services/coupon/CouponManager.scala
+++ b/phoenix-scala/app/services/coupon/CouponManager.scala
@@ -53,7 +53,7 @@ object CouponManager {
   private def forceActivate(attributes: Map[String, Json]): Map[String, Json] =
     attributes
       .updated("activeFrom", ("t" → "datetime") ~ ("v" → Instant.ofEpochMilli(1).toString))
-      .updated("activeTo", JNull)
+      .updated("activeTo", ("t"   → "datetime") ~ ("v" → JNull))
 
   def update(id: Int, payload: UpdateCoupon, contextName: String, admin: User)(
       implicit ec: EC,


### PR DESCRIPTION
Resolves #1431

If we had #1475, this would have been caught earlier. In fact, @mempko is fixing this line right there, too. =)

/cc @anna-zzz 

I tried to reproduce this in tests, but failed. There are tests that delete such coupons, but they work somehow. Also, deleting in UI works for me without this change.