### PR TITLE
Fix: styles drop in RichTextEditor

### DIFF
--- a/ashes/package.json
+++ b/ashes/package.json
@@ -101,7 +101,6 @@
     "sprout-data": "^0.2.3",
     "superagent": "^3.5.0",
     "thunkify-wrap": "^1.0.4",
-    "to-markdown": "^3.0.4",
     "use-named-routes": "^0.3.0",
     "victory": "^0.15.0",
     "zipcodes-regex": "^1.0.0"

--- a/ashes/src/components/rich-text-editor/rich-text-editor.jsx
+++ b/ashes/src/components/rich-text-editor/rich-text-editor.jsx
@@ -10,7 +10,6 @@ import { stateFromHTML } from 'draft-js-import-html';
 import { stateToHTML } from 'draft-js-export-html';
 import { stateFromMarkdown } from 'draft-js-import-markdown';
 import { stateToMarkdown } from 'draft-js-export-markdown';
-import toMarkdown from 'to-markdown';
 
 // components
 import { ContentBlock, ContentState, Editor, EditorState, RichUtils } from 'draft-js';
@@ -118,7 +117,7 @@ export default class RichTextEditor extends Component {
       if (!this.state.richMode) {
         const textValue = (this.state.contentType === 'html')
           ? this.htmlContent
-          : toMarkdown(this.htmlContent);
+          : stateToMarkdown(stateFromHTML(this.htmlContent));
 
         this.setState({
           editorState: EditorState.createWithContent(ContentState.createFromText(textValue))


### PR DESCRIPTION
This PR fixes style drop after mode switch. 

Note: here is a known edge case with `italic`-style on the beginning/center of a word. Which is connected to issue of the external lib: https://github.com/sstur/react-rte/issues/199 