### PR TITLE
add postcss-nested

### DIFF
--- a/ashes/package.json
+++ b/ashes/package.json
@@ -177,7 +177,7 @@
     "postcss-modules-extract-imports": "^1.0.0",
     "postcss-modules-local-by-default": "^1.0.1",
     "postcss-modules-scope": "^1.0.0",
-    "postcss-modules-values": "^1.1.2",
+    "postcss-nested": "^1.0.1",
     "query-string": "^4.2.2",
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0",

--- a/ashes/src/components/core/button-with-menu/button-with-menu.css
+++ b/ashes/src/components/core/button-with-menu/button-with-menu.css
@@ -2,12 +2,6 @@
   display: inline-block;
   vertical-align: top;
   position: relative;
-}
-
-.button.opened {
-  & .menu {
-    display: inline-block;
-  }
 
   & :global .fc-button-with-menu__right-button i {
     transform: rotateX(180deg);
@@ -28,6 +22,10 @@
   overflow-y: auto;
   overflow-x: hidden;
   text-align: left;
+
+  .button.opened & {
+    display: inline-block;
+  }
 }
 
 .controls {

--- a/ashes/src/postcss.js
+++ b/ashes/src/postcss.js
@@ -36,7 +36,7 @@ const plugins = [
     gutter: '1.85%',
   }),
   require('postcss-mixins'),
-  require('postcss-modules-values'),
+  require('postcss-nested'),
   require('postcss-modules-extract-imports'),
   require('postcss-modules-local-by-default'),
   require('postcss-modules-scope')({

--- a/ashes/yarn.lock
+++ b/ashes/yarn.lock
@@ -7256,12 +7256,18 @@ postcss-modules-scope@1.0.2, postcss-modules-scope@^1.0.0:
     css-selector-tokenizer "^0.6.0"
     postcss "^5.0.4"
 
-postcss-modules-values@1.2.2, postcss-modules-values@^1.1.0, postcss-modules-values@^1.1.2:
+postcss-modules-values@1.2.2, postcss-modules-values@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz#f0e7d476fe1ed88c5e4c7f97533a3e772ad94ca1"
   dependencies:
     icss-replace-symbols "^1.0.2"
     postcss "^5.0.14"
+
+postcss-nested@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-1.0.1.tgz#91f28f4e6e23d567241ac154558a0cfab4cc0d8f"
+  dependencies:
+    postcss "^5.2.17"
 
 postcss-nesting@^2.0.5:
   version "2.3.1"
@@ -7413,9 +7419,9 @@ postcss@^5.0.0, postcss@^5.0.14, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.5
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.16, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.3, postcss@^5.0.8, postcss@^5.1.1, postcss@^5.2.0, postcss@^5.2.13, postcss@^5.2.15, postcss@^5.2.16, postcss@^5.2.4, postcss@^5.2.6:
-  version "5.2.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.16.tgz#732b3100000f9ff8379a48a53839ed097376ad57"
+postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.16, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.3, postcss@^5.0.8, postcss@^5.1.1, postcss@^5.2.0, postcss@^5.2.13, postcss@^5.2.15, postcss@^5.2.16, postcss@^5.2.17, postcss@^5.2.4, postcss@^5.2.6:
+  version "5.2.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
   dependencies:
     chalk "^1.1.3"
     js-base64 "^2.1.9"


### PR DESCRIPTION
## What was done

1. Add `postcss-nested` [plugin](https://www.npmjs.com/package/postcss-nested)
2. Remove `postcss-modules-values` [plugin](https://www.npmjs.com/package/postcss-modules-values) since it is not used.

## Why

I think it is more convenient to group css code around _element_, not around _parent_ (see code diff).