### PR TITLE
Nix shell derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,7 @@ in with import nixpkgs {}; {
     });
   in stdenv.mkDerivation {
     name = "ashes";
-    buildInputs = [ gcc pkgconfig fontconfig cairo libpng pixman nodejs-6_x flow25 ];
+    buildInputs = [ gcc pkgconfig fontconfig yarn cairo libpng pixman nodejs-6_x flow25 ];
     shellHook = ''
       source .env.local
       cd ashes


### PR DESCRIPTION
`make prepare` asks me for my root password, which is **pretty insane**.

Here’s a PR with @kjanosz’s `default.nix` that set ups the environment, there was a branch but no PR.

I pinned it to Nixpkgs 16.09 for greater reproducibility.

Example usage:

```
  # in your normal shell:

% nix-shell -A main

  # drops you to a new Bash shell with all the deps of the `main' attr (defined below)

$ make up
```