### PR TITLE
Fix double decoding payload in green-river for activities

### DIFF
--- a/green-river/src/main/scala/consumer/AvroProcessor.scala
+++ b/green-river/src/main/scala/consumer/AvroProcessor.scala
@@ -13,9 +13,8 @@ import org.apache.avro.io.EncoderFactory
 import org.apache.kafka.common.errors.SerializationException
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Parser
-
-import org.json4s.JsonAST.{JValue, JObject, JField, JString}
-import org.json4s.jackson.JsonMethods.{render, compact, parse}
+import org.json4s.JsonAST.{JField, JObject, JString, JValue}
+import org.json4s.jackson.JsonMethods.{compact, parse, render}
 
 import scala.util.control.NonFatal
 
@@ -24,9 +23,9 @@ object AvroProcessor {
   //Make sure the scoped_activities avro schema is registered
   val activityAvroSchema = """
       |{
-      |  "type":"record",
-      |  "name":"scoped_activities",
-      |  "fields":[
+      |  "type": "record",
+      |  "name": "scoped_activities",
+      |  "fields": [
       |    {
       |      "name":"id",
       |      "type":["null","string"]

--- a/green-river/src/main/scala/consumer/activity/ActivityProcessor.scala
+++ b/green-river/src/main/scala/consumer/activity/ActivityProcessor.scala
@@ -71,7 +71,7 @@ class ActivityProcessor(
 
   implicit val formats: DefaultFormats.type = DefaultFormats
 
-  val activityJsonFields = List("id", "activityType", "data", "context", "createdAt")
+  val activityJsonFields = List("data", "context", "createdAt")
   val phoenix            = Phoenix(conn)
   val kafkaProps = {
     val props = new Properties()


### PR DESCRIPTION
- Fix next error:
	`Error during parsing field id: Unrecognized token 'phoenix': was expecting ('true', 'false' or 'null')`.
We are lucky we have a workaround for this error: bypass data as is in this case.
- Fix false positive success while write to kafka. Right now In case of error phoenix prints success and skip error at all.
