### PR TITLE
Force seeder to use port 55555

### DIFF
--- a/hyperion/Dockerfile.seed
+++ b/hyperion/Dockerfile.seed
@@ -12,6 +12,7 @@ ARG db_user="hyperion"
 ARG db_password=""
 ARG push_check_interval=5
 ARG hyperion_env=prod
+ARG hyperion_port=55555
 
 ENV HYPERION_DB_NAME $db_name
 ENV HYPERION_DB_USER $db_user
@@ -19,6 +20,7 @@ ENV HYPERION_DB_PASSWORD $db_password
 ENV HYPERION_DB_HOST $db_host
 ENV PUSH_CHECK_INTERVAL $push_check_interval
 ENV MIX_ENV $hyperion_env
+ENV PORT $hyperion_port
 
 RUN mix local.hex --force
 RUN mix local.rebar --force


### PR DESCRIPTION
Fix seeder `port already in use` error