### PR TITLE
Fix: change sku code error message text

### DIFF
--- a/ashes/src/components/products/skus/editable-sku-row.jsx
+++ b/ashes/src/components/products/skus/editable-sku-row.jsx
@@ -245,7 +245,7 @@ class EditableSkuRow extends Component {
 
   skuCell(sku: Sku): Element<*> {
     const { codeError } = this.state;
-    const error = codeError ? `SKU Code violates constraint: ${codeError.keyword}` : void 0;
+    const error = codeError ? `SKU code can't be empty` : void 0;
     return (
       <div styleName="sku-cell">
         <FormField error={error} scrollToErrors>


### PR DESCRIPTION
This change is appropriate unless SKU code has the only limitation: min length. (according to the product schema)