### PR TITLE
anthill es configs

### DIFF
--- a/intelligence/anthill/src/router.py
+++ b/intelligence/anthill/src/router.py
@@ -8,7 +8,9 @@ from util.neo4j_utils import Neo4j_Client
 
 APP = Flask(__name__)
 NEO4J_CLIENT = Neo4j_Client()
-ES_CLIENT = ES_Client(os.getenv('ES_HOST'), os.getenv('ES_PORT'))
+ES_CLIENT = ES_Client(
+        os.getenv('ES_HOST', 'elasticsearch.service.consul'),
+        os.getenv('ES_PORT', '9200'))
 PP_MANAGER = Prod_Prod_Manager(NEO4J_CLIENT, ES_CLIENT)
 
 # Register Middleware

--- a/intelligence/anthill/src/util/ES_Client.py
+++ b/intelligence/anthill/src/util/ES_Client.py
@@ -47,7 +47,7 @@ class ES_Client(object):
         self.host = host
         self.port = port
         self.header = {'Content-Type': 'application/json'}
-        self.url = '/api/search/public/products_catalog_view/_search'
+        self.url = '/public/products_catalog_view/_search'
 
     def get_full_url(self, from_param, size_param):
         """get_full_url
@@ -63,7 +63,7 @@ class ES_Client(object):
             body = products_list_query(prod_ids)
         else:
             body = match_all_query()
-        conn = http.client.HTTPSConnection(self.host)
+        conn = http.client.HTTPConnection(self.host, self.port)
         conn.request(
             method='POST',
             url=self.get_full_url(from_param, size_param),
@@ -71,5 +71,5 @@ class ES_Client(object):
             headers=self.header)
         resp = conn.getresponse().read().decode('utf-8')
         conn.close()
-        output = json.loads(resp)
+        output = cleanup_search_result(json.loads(resp))
         return output


### PR DESCRIPTION
* revert changes that removed json cleanup in anthill
* add default values for es related env variables

For the changes merged in https://github.com/FoxComm/highlander/pull/1562 , the anthill container needs the environment variables:
- `ES_HOST=elasticsearch.service.consul`
- `ES_PORT=9200`

These are set in the updated tabernacle templates in the same pull request.