### PR TITLE
bugfix: data-import login error

### DIFF
--- a/data-import/src/main.py
+++ b/data-import/src/main.py
@@ -88,7 +88,9 @@ class Elasticsearch:
         req = urllib.request.Request(endpoint, headers={"Content-Type": "application/json", "JWT": self.jwt})
 
         try:
-            response = urllib.request.urlopen(req)
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            response = urllib.request.urlopen(req, context=context)
         except HTTPError as err:
             print(repr(err))
             raise
@@ -140,7 +142,9 @@ class Phoenix:
                                      method=method)
 
         try:
-            response = urllib.request.urlopen(req)
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            response = urllib.request.urlopen(req, context=context)
         except HTTPError as err:
             print("HTTP error. code: {}. message: {}".format(err.code, err.read()))
             raise


### PR DESCRIPTION
The variable `api_server` may be something like balancer.service.consul
which will cause the urllib request to fail:
```
ssl.CertificateError: hostname 'balancer.service.consul' doesn't match either of '*.foxcommerce.com', 'foxcommerce.com'
```

This fix turns off host checking before making the log in request.