### PR TITLE
bug: Anthill fail on startup

### DIFF
--- a/intelligence/anthill/src/util/neo4j_utils.py
+++ b/intelligence/anthill/src/util/neo4j_utils.py
@@ -6,7 +6,10 @@ def get_all_channels(client):
     """get_all_channels
     """
     client.start()
-    query = "MATCH ()-[r:PURCHASED]-() RETURN DISTINCT r.channel"
+    query = """
+        MATCH ()-[r:PURCHASED]-()
+        WHERE r.channel IS NOT NULL
+        RETURN DISTINCT r.channel"""
     result = client.session.run(query)
     out = [record['r.channel'] for record in result]
     client.stop()


### PR DESCRIPTION
If purchases with null channels exist in neo4j, anthill will fail to start up.
Fixed by filtering out null channels in neo4j query.