### PR TITLE
Make archived SKUs inaccessible via PDP

### DIFF
--- a/phoenix-scala/app/routes/Public.scala
+++ b/phoenix-scala/app/routes/Public.scala
@@ -36,7 +36,7 @@ object Public {
             pathPrefix(ProductRef) { productId ⇒
               (get & pathEnd) {
                 getOrFailures {
-                  ProductManager.getProduct(productId)
+                  ProductManager.getProduct(productId, checkActive = true)
                 }
               }
             }


### PR DESCRIPTION
Resolves #1389

Can we all agree now that default arguments are *freaking ~stupid~ silly*?

(~Stupid~ Silly as in useless.)

https://github.com/wartremover/wartremover/issues/116#issuecomment-51077274 and the following discussion from 2014 for context.