### PR TITLE
Change to use channels and threads in digger-sphex

### DIFF
--- a/intelligence/consumers/digger-sphex/counter.p6
+++ b/intelligence/consumers/digger-sphex/counter.p6
@@ -67,60 +67,89 @@ sub MAIN ($kafka-host, $kafka-topic, $henhouse-host)
 
     my $henhouse = IO::Socket::INET.new(:host($henhouse-host), :port<2003>);
 
-    my $track-supplier = Supplier.new;
-    my $track-supply = $track-supplier.Supply;
+    my $track-channel = Channel.new;
+    my $count-channel = Channel.new;
+    my $counts = 0;
 
-        $log.messages.tap(-> $msg
-        {
-            given $msg
-            {
-                when PKafka::Message
-                {
-                    my $r = Nginx.parse($msg.payload-str);
-                    send-to-henhouse($r, $track-supplier) if $r<cmd>;
-                    $log.save-offset($msg);
-                }
-                when PKafka::EOF
-                {
-                    say "Messages Consumed { $msg.total-consumed}";
-                }
-                when PKafka::Error
-                {
-                    say "Error {$msg.what}";
-                    $log.stop;
-                }
-            }
-        });
-
-    $track-supply.tap(-> $msg
+    $log.messages.tap(-> $msg
     {
-        my $stat = "{$msg.key} {$msg.count} {$msg.time}";
-
-        #send to henhouse
-        $henhouse.print("$stat\n");
+        given $msg
+        {
+            when PKafka::Message
+            {
+                my $r = Nginx.parse($msg.payload-str);
+                send-to-henhouse($r, $track-channel, $count-channel) if $r<cmd>;
+                $log.save-offset($msg);
+            }
+            when PKafka::EOF
+            {
+                say "Messages Consumed { $msg.total-consumed}, with $counts Counts";
+            }
+            when PKafka::Error
+            {
+                say "Error {$msg.what}";
+                $log.stop;
+            }
+        }
     });
+
+    my $track-thread = start {
+        say "Track Thread Started";
+        react {
+            whenever $track-channel -> $msg {
+                track($count-channel, $msg.key, $msg.time);
+            }
+        }
+        say "Track Thread Stopped";
+    }
+
+    my $count-thread = start {
+        say "Count Thread Started";
+        react {
+            whenever $count-channel -> $msg {
+                my $stat = "{$msg.key} {$msg.count} {$msg.time}";
+
+                #send to henhouse
+                $henhouse.print("$stat\n");
+
+                $counts++;
+            }
+        }
+        say "Count Thread Stopped";
+    }
 
     say "Reading from kakfa...";
 
     my $log-promise = $log.consume-from-last(partition=>0);
 
     await $log-promise;
-    $track-supplier.done();
+
+    $track-channel.close;
+    $count-channel.close;
+
+    await $track-thread;
+    await $count-thread;
 }
 
-class TrackMsg
+class CountMsg
 {
     has Int $.count;
     has Str $.key;
     has Int $.time;
 }
 
-sub count($supplier, Int $count, Int $time, Str $key)
+class TrackMsg
 {
-    $supplier.emit(TrackMsg.new(count=> $count, key=> $key, time=>$time))
+    has Str $.key;
+    has Int $.time;
 }
 
-sub track($supplier, $path, Int $time)
+sub count($channel is rw, Int $count, Int $time, Str $key)
+{
+    $channel.send(CountMsg.new(count=>$count, key=> $key, time=>$time));
+}
+
+sub track($count-channel is rw, $path, Int $time)
 {
     my %args = Hal.parse($path, actions=>HalArgs).made;
     return if not %args<ch>:exists;
@@ -140,20 +169,20 @@ sub track($supplier, $path, Int $time)
 
     my $cluster = 1; #TODO, get these from tracking url
 
-    count($supplier, $count, $time, "track.$channel.$cluster.$object.$object-id.$verb.$subject");
-    count($supplier, $count, $time, "track.$channel.$cluster.$object.$object-id.$verb");
-    count($supplier, $count, $time, "track.$channel.$cluster.$object.$verb");
-    count($supplier, $count, $time, "track.$channel.$object.$object-id.$verb.$subject");
-    count($supplier, $count, $time, "track.$channel.$object.$object-id.$verb");
-    count($supplier, $count, $time, "track.$channel.$object.$verb");
-    count($supplier, $count, $time, "track.$object.$object-id.$verb.$subject");
-    count($supplier, $count, $time, "track.$object.$object-id.$verb");
-    count($supplier, $count, $time, "track.$object.$verb");
-    count($supplier, $count, $time, "track.$verb.$subject");
-    count($supplier, $count, $time, "track.$verb");
+    count($count-channel, $count, $time, "track.$channel.$cluster.$object.$object-id.$verb.$subject");
+    count($count-channel, $count, $time, "track.$channel.$cluster.$object.$object-id.$verb");
+    count($count-channel, $count, $time, "track.$channel.$cluster.$object.$verb");
+    count($count-channel, $count, $time, "track.$channel.$object.$object-id.$verb.$subject");
+    count($count-channel, $count, $time, "track.$channel.$object.$object-id.$verb");
+    count($count-channel, $count, $time, "track.$channel.$object.$verb");
+    count($count-channel, $count, $time, "track.$object.$object-id.$verb.$subject");
+    count($count-channel, $count, $time, "track.$object.$object-id.$verb");
+    count($count-channel, $count, $time, "track.$object.$verb");
+    count($count-channel, $count, $time, "track.$verb.$subject");
+    count($count-channel, $count, $time, "track.$verb");
 }
 
-sub send-to-henhouse($r, $supplier)
+sub send-to-henhouse($r, $track-channel is rw, $count-channel is rw)
 {
     #only count things river-rock proxies
     return if not $r<host> ~~ m/river\-rock/;
@@ -163,11 +192,14 @@ sub send-to-henhouse($r, $supplier)
 
     if $r<path> ~~ m/api\/v1\/hal/
     {
-        track($supplier, $r<path>, $time)
+        $track-channel.send(TrackMsg.new(key=>"$r<path>", time=>$time));
     } 
     else 
     {
-        count($supplier, 1, $time, "$r<path>.$r<cmd>.$r<response>");
+        count($count-channel, 1, $time, "$r<path>.$r<cmd>.$r<response>");
+        count($count-channel, 1, $time, "$r<cmd>.$r<response>");
+        count($count-channel, 1, $time, "$r<cmd>");
+        count($count-channel, 1, $time, "$r<response>");
     }
 }
 


### PR DESCRIPTION
1. Spawn thread to track and count.
2. Use channels to communicate tracking and counting.
3. Also track requests by type and response code.