### PR TITLE
Async import for analytics route

### DIFF
--- a/ashes/src/components/analytics/analytics.jsx
+++ b/ashes/src/components/analytics/analytics.jsx
@@ -155,7 +155,7 @@ percentDifferenceFromAvg(percentValue: number, avgPercentValue: number): number 
 }
 
 @connect((state, props) => ({analytics: state.analytics}), AnalyticsActions)
-export default class Analytics extends React.Component {
+export class Analytics extends React.Component {
 
   static defaultProps: {
     questionBoxes: Array<QuestionBoxType>,

--- a/ashes/src/components/analytics/trend-button.css
+++ b/ashes/src/components/analytics/trend-button.css
@@ -2,50 +2,44 @@
   display: inline-block;
   background-color: #49CA8E;
   border-radius: 24px;
-  height: 24px;
 }
 
 .trend-button-container-loss {
   display: inline-block;
   background-color: #F65554;
   border-radius: 24px;
-  height: 24px;
 }
 
 .trend-button-container-steady {
   display: inline-block;
   background-color: #CED2D5;
   border-radius: 24px;
-  height: 24px;
 }
 
 .trend-button-content-gain {
   display: inline-block;
   color: white;
-  padding-right: 12px;
-  padding-left: 12px;
-  line-height: 0;
+  padding: 4px 12px;
   font-size: 12px;
+  margin-bottom: 0;
   margin-top: 0;
 }
 
 .trend-button-content-loss {
   display: inline-block;
   color: white;
-  padding-right: 12px;
-  padding-left: 12px;
-  line-height: 0;
+  padding: 4px 12px;
   font-size: 12px;
+  margin-bottom: 0;
   margin-top: 0;
 }
 
 .trend-button-content-steady {
   display: inline-block;
   color: black;
-  padding-right: 12px;
-  padding-left: 12px;
-  line-height: 0;
+  padding: 4px 12px;
   font-size: 12px;
+  margin-bottom: 0;
   margin-top: 0;
 }
 

--- a/ashes/src/components/analytics/trend-button.jsx
+++ b/ashes/src/components/analytics/trend-button.jsx
@@ -56,10 +56,7 @@ const TrendButton = (props: Props) => {
   return(
     <div styleName={`trend-button-container-${trendType.style}`}>
       <p styleName={`trend-button-content-${trendType.style}`}>
-        <img
-          styleName={`trend-button-arrow-${arrow.direction}`}
-          src={`/admin/images/arrow-${arrow.color}.svg`}
-        />
+        <i className={`icon-chevron-${arrow.direction}`} styleName={`trend-button-arrow-${arrow.direction}`} />
         {contentBody}
       </p>
     </div>

--- a/ashes/src/components/live-search/live-search.jsx
+++ b/ashes/src/components/live-search/live-search.jsx
@@ -645,7 +645,7 @@ export default class LiveSearch extends React.Component {
                 formatPill={this.formatPill}
                 icon={null}
                 pills={this.state.pills}>
-              {/* @todo get back MaskedInput */}
+              {/* @todo get back MaskedInput prepend={this.state.searchPrepend} */}
                 <input
                   className="fc-pilled-input__input-field _no-fc-behavior"
                   mask={this.state.inputMask}
@@ -654,7 +654,7 @@ export default class LiveSearch extends React.Component {
                   onBlur={this.blur}
                   onKeyDown={this.keyDown}
                   placeholder={this.props.placeholder}
-                  prepend={this.state.searchPrepend}
+
                   value={this.state.searchDisplay}
                   disabled={this.isDisabled}
                   ref={i => this._input = i} />

--- a/ashes/src/components/object-page/object-page.jsx
+++ b/ashes/src/components/object-page/object-page.jsx
@@ -219,7 +219,8 @@ export class ObjectPage extends Component {
         });
     }
 
-    this.props.actions.fetchAmazonStatus();
+    this.props.actions.fetchAmazonStatus()
+      .catch(() => {}); // pass
   }
 
   get unsaved(): boolean {

--- a/ashes/src/routes/catalog.js
+++ b/ashes/src/routes/catalog.js
@@ -4,7 +4,6 @@ import React, { Component, Element } from 'react';
 import FoxRouter from 'lib/fox-router';
 import { frn } from 'lib/frn';
 
-import Analytics from 'components/analytics/analytics';
 import ActivityTrailPage from 'components/activity-trail/activity-trail-page';
 import Notes from 'components/notes/notes';
 
@@ -75,7 +74,10 @@ const getRoutes = (jwt: Object) => {
         router.read('product-analytics', {
           title: 'Analytics',
           path: 'analytics',
-          component: Analytics,
+          getComponent: (location, callback) => {
+            import('../components/analytics/analytics')
+              .then(({ Analytics }) => callback(null, Analytics));
+          },
           frn: frn.activity.product,
         }),
       ]),

--- a/ashes/webpack/prod.js
+++ b/ashes/webpack/prod.js
@@ -21,12 +21,14 @@ module.exports = {
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
           use: [ 'css-loader', 'postcss-loader' ]
         })
       },
       {
         test: /\.less$/,
         use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
           use: [ 'css-loader', 'less-loader' ]
         })
       },
@@ -52,7 +54,7 @@ module.exports = {
 
     new ManifestPlugin(),
 
-    new ExtractTextPlugin('app.[contenthash:6].css'),
+    new ExtractTextPlugin('[name].[contenthash:6].css'),
     new OptimizeCssAssetsPlugin(),
   ],
 


### PR DESCRIPTION
## What was done

1. Proof of concept: async imports for route components. `victory` lib now in additional chunk. `466 kb` saved.
2. Async css: all css from additional chunks now loads with `style-loader`. `app.css` contains only css from primary chunk.
3. Remove some reds from console.

![2017-05-21 10 43 41](https://cloud.githubusercontent.com/assets/2929442/26282104/f7f0784c-3e12-11e7-8f4a-167df8b832e9.png)

start chunks were: `3.3 mb`
start chunks now: `2.8 mb`

![js](https://cloud.githubusercontent.com/assets/2929442/26282249/1817bb14-3e16-11e7-8fb2-e3810d00f644.gif)

app.css was: `237 kb`
app.css now: `233 kb`

![css](https://cloud.githubusercontent.com/assets/2929442/26282250/1b5966b0-3e16-11e7-9a5e-a78b209cf771.gif)
