### PR TITLE
Messaging, fix decoding payloads with quoted strings

### DIFF
--- a/messaging/src/messaging/core.clj
+++ b/messaging/src/messaging/core.clj
@@ -26,7 +26,6 @@
 (defn decode-embed-json
   [^String s]
   (some-> s
-          (string/replace #"\\" "")
           json/parse-string))
 
 (defn decode-activity-json


### PR DESCRIPTION
It was introduced by using previous json library,
which have uncorrect behaviour with double-encoded json
with quoting.