### PR TITLE
Mwh/kangaroos sku migration2

### DIFF
--- a/middlewarehouse/consumers/stock-items/consumer.go
+++ b/middlewarehouse/consumers/stock-items/consumer.go
@@ -68,13 +68,6 @@ func (consumer *StockItemsConsumer) Handler(m metamorphosis.AvroMessage) error {
 		log.Panicf("Error unmarshaling from Avro with error: %s", err.Error())
 	}
 
-	log.Printf("Prepare StockItem and SKU data")
-	stockItem := sku.StockItem(1)
-	b, err := json.Marshal(&stockItem)
-	if err != nil {
-		log.Panicf("Error marshaling to stock item with error: %s", err.Error())
-	}
-
 	skuReq := sku.CreateSKU()
 	skuJson, err := json.Marshal(&skuReq)
 	if err != nil {
@@ -88,7 +81,6 @@ func (consumer *StockItemsConsumer) Handler(m metamorphosis.AvroMessage) error {
 	jwt := consumer.phoenixClient.GetJwt()
 
 	log.Printf("Send requests to middlewarehouse")
-	consumer.sendRequest("v1/public/stock-items", bytes.NewBuffer(b), jwt)
 	consumer.sendRequest("v1/public/skus", bytes.NewBuffer(skuJson), jwt)
 
 	log.Printf("Message handler finished processing")

--- a/middlewarehouse/consumers/stock-items/sku.go
+++ b/middlewarehouse/consumers/stock-items/sku.go
@@ -33,14 +33,6 @@ func NewSKUFromAvro(message metamorphosis.AvroMessage) (*SKU, error) {
 	return s, nil
 }
 
-func (s SKU) StockItem(stockLocationID uint) payloads.StockItem {
-	return payloads.StockItem{
-		SKU:             s.Code,
-		StockLocationID: stockLocationID,
-		DefaultUnitCost: 0,
-	}
-}
-
 func (s SKU) CreateSKU() payloads.CreateSKU {
 	return payloads.CreateSKU{
 		Code:             s.Code,

--- a/middlewarehouse/services/sku_service.go
+++ b/middlewarehouse/services/sku_service.go
@@ -109,6 +109,49 @@ func (s *skuService) Archive(id uint) error {
 	return s.db.Delete(&sku).Error
 }
 
+func (s *skuService) upsertSku(txn *gorm.DB, sku *models.SKU) error {
+	onConflict := `ON CONFLICT (code) DO UPDATE SET 
+				scope = EXCLUDED.scope, 
+				upc = EXCLUDED.upc, 
+				title=EXCLUDED.title, 
+				unit_cost_currency=EXCLUDED.unit_cost_currency, 
+				unit_cost_value=EXCLUDED.unit_cost_value,
+				tax_class=EXCLUDED.tax_class,
+				requires_shipping=EXCLUDED.requires_shipping,
+				shipping_class=EXCLUDED.shipping_class,
+				is_returnable=EXCLUDED.is_returnable,
+				return_window_value=EXCLUDED.return_window_value,
+				return_window_units=EXCLUDED.return_window_units,
+				height_value=EXCLUDED.height_value,
+				height_units=EXCLUDED.height_units,
+				weight_value=EXCLUDED.weight_value,
+				weight_units=EXCLUDED.length_value,
+				length_value=EXCLUDED.length_value,
+				length_units=EXCLUDED.length_units,
+				width_value=EXCLUDED.width_value,
+				width_units=EXCLUDED.width_units,
+				requires_inventory_tracking=EXCLUDED.requires_inventory_tracking,
+				inventory_warning_level_is_enabled=EXCLUDED.inventory_warning_level_is_enabled,
+				inventory_warning_level_value=EXCLUDED.inventory_warning_level_value,
+				maximum_quantity_in_cart_value=EXCLUDED.maximum_quantity_in_cart_value,
+				maximum_quantity_in_cart_is_enabled=EXCLUDED.maximum_quantity_in_cart_is_enabled,
+				minimum_quantity_in_cart_value=EXCLUDED.minimum_quantity_in_cart_value,
+				minimum_quantity_in_cart_is_enabled=EXCLUDED.minimum_quantity_in_cart_is_enabled,
+				allow_backorder=EXCLUDED.allow_backorder,
+				allow_preorder=EXCLUDED.allow_preorder,
+				requires_lot_tracking=EXCLUDED.requires_lot_tracking,
+				lot_expiration_threshold_value=EXCLUDED.lot_expiration_threshold_value,
+				lot_expiration_threshold_units=EXCLUDED.lot_expiration_threshold_units,
+				lot_expiration_warning_threshold_value=EXCLUDED.lot_expiration_warning_threshold_value,
+				lot_expiration_warning_threshold_units=EXCLUDED.lot_expiration_warning_threshold_units`
+
+	if err := txn.Set("gorm:insert_option", onConflict).Create(sku).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *skuService) createInner(txn *gorm.DB, payload *payloads.CreateSKU) (*responses.SKU, error) {
 	sku := payload.Model()
 
@@ -116,7 +159,7 @@ func (s *skuService) createInner(txn *gorm.DB, payload *payloads.CreateSKU) (*re
 		return nil, err
 	}
 
-	if err := txn.Create(sku).Error; err != nil {
+	if err := s.upsertSku(txn, sku); err != nil {
 		return nil, err
 	}
 

--- a/middlewarehouse/sql/V000034__add_unique_constraint_sku_code.sql
+++ b/middlewarehouse/sql/V000034__add_unique_constraint_sku_code.sql
@@ -1,0 +1,1 @@
+alter table skus add constraint unique_code UNIQUE (code);


### PR DESCRIPTION
Related to #1858 and depends on #1887 
- Modified stock_item_consumer to add SKU in MWH DB every time there is a change in SKU in Phoenix.
- Changed SKU POST behaviour to UPSERT. Previously new SKU was always created.