### PR TITLE
Get rid of CartLineItemAdjustment dependency in discounts

### DIFF
--- a/phoenix-scala/phoenix/app/phoenix/models/cord/lineitems/CartLineItemAdjustment.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/cord/lineitems/CartLineItemAdjustment.scala
@@ -5,6 +5,8 @@ import java.time.Instant
 import com.pellucid.sealerate
 import core.db.ExPostgresDriver.api._
 import core.db._
+import phoenix.models.discount.offers.Offer.OfferResult
+import phoenix.models.discount.offers._
 import phoenix.utils.ADT
 import shapeless._
 import slick.ast.BaseTypedType
@@ -40,6 +42,22 @@ object CartLineItemAdjustment {
   case object OrderAdjustment    extends AdjustmentType
   case object ShippingAdjustment extends AdjustmentType
   case object Combinator         extends AdjustmentType
+
+  def fromOfferResult(offerResult: OfferResult) =
+    CartLineItemAdjustment(cordRef = offerResult.discountInput.cart.refNum,
+                           promotionShadowId = offerResult.discountInput.promotion.id,
+                           adjustmentType = adjustmentTypeByOffer(offerResult.offerType),
+                           subtract = offerResult.subtract,
+                           lineItemRefNum = offerResult.lineItemRefNum)
+
+  def adjustmentTypeByOffer(offerType: OfferType): AdjustmentType = offerType match {
+    case ItemPercentOff | ItemAmountOff    ⇒ LineItemAdjustment
+    case ItemsPercentOff | ItemsAmountOff  ⇒ LineItemAdjustment
+    case SetPrice                          ⇒ LineItemAdjustment
+    case OrderPercentOff | OrderAmountOff  ⇒ OrderAdjustment
+    case FreeShipping | DiscountedShipping ⇒ ShippingAdjustment
+    case ListCombinator                    ⇒ Combinator
+  }
 
   object AdjustmentType extends ADT[AdjustmentType] {
     def types = sealerate.values[AdjustmentType]

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/DiscountedShippingOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/DiscountedShippingOffer.scala
@@ -1,6 +1,6 @@
 package phoenix.models.discount.offers
 
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
+import core.db.Result
 import phoenix.models.discount.DiscountInput
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.aliases._
@@ -8,10 +8,12 @@ import phoenix.utils.apis.Apis
 
 case class DiscountedShippingOffer(discount: Int) extends Offer with AmountOffer {
 
-  val offerType: OfferType           = DiscountedShipping
-  val adjustmentType: AdjustmentType = ShippingAdjustment
+  val offerType: OfferType = DiscountedShipping
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     input.shippingMethod match {
       case Some(sm) if discount > 0 ⇒ buildResult(input, subtract(sm.price, discount))
       case _                        ⇒ pureResult()

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/FreeShippingOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/FreeShippingOffer.scala
@@ -1,6 +1,6 @@
 package phoenix.models.discount.offers
 
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
+import core.db.Result
 import phoenix.models.discount.DiscountInput
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.aliases._
@@ -8,10 +8,12 @@ import phoenix.utils.apis.Apis
 
 case object FreeShippingOffer extends Offer {
 
-  val offerType: OfferType           = FreeShipping
-  val adjustmentType: AdjustmentType = ShippingAdjustment
+  val offerType: OfferType = FreeShipping
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     input.shippingMethod match {
       case Some(sm) ⇒ buildResult(input, sm.price)
       case _        ⇒ pureResult()

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemAmountOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemAmountOffer.scala
@@ -1,9 +1,8 @@
 package phoenix.models.discount.offers
 
 import cats.implicits._
+import core.db.Result
 import core.failures._
-import phoenix.models.cord.lineitems.CartLineItemAdjustment
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.ElasticsearchApi._
@@ -17,14 +16,16 @@ case class ItemAmountOffer(discount: Int, search: Seq[ProductSearch])
     with NonEmptySearch
     with ItemsOffer {
 
-  val offerType: OfferType           = ItemAmountOff
-  val adjustmentType: AdjustmentType = LineItemAdjustment
+  val offerType: OfferType = ItemAmountOff
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (discount > 0) adjustInner(input)(search) else pureResult()
 
   def matchEither(input: DiscountInput)(
-      either: Either[Failures, Buckets]): Either[Failures, Seq[CartLineItemAdjustment]] =
+      either: Either[Failures, Buckets]): Either[Failures, Seq[OfferResult]] =
     either match {
       case Right(buckets) ⇒
         val matchedFormIds = buckets.filter(_.docCount > 0).map(_.key)

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemPercentOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemPercentOffer.scala
@@ -1,9 +1,8 @@
 package phoenix.models.discount.offers
 
 import cats.implicits._
+import core.db.Result
 import core.failures._
-import phoenix.models.cord.lineitems.CartLineItemAdjustment
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.ElasticsearchApi._
@@ -17,14 +16,16 @@ case class ItemPercentOffer(discount: Int, search: Seq[ProductSearch])
     with NonEmptySearch
     with ItemsOffer {
 
-  val offerType: OfferType           = ItemPercentOff
-  val adjustmentType: AdjustmentType = LineItemAdjustment
+  val offerType: OfferType = ItemPercentOff
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (discount > 0 && discount < 100) adjustInner(input)(search) else pureResult()
 
   def matchEither(input: DiscountInput)(
-      either: Either[Failures, Buckets]): Either[Failures, Seq[CartLineItemAdjustment]] =
+      either: Either[Failures, Buckets]): Either[Failures, Seq[OfferResult]] =
     either match {
       case Right(buckets) ⇒
         val matchedFormIds = buckets.filter(_.docCount > 0).map(_.key)

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemsAmountOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemsAmountOffer.scala
@@ -1,9 +1,8 @@
 package phoenix.models.discount.offers
 
 import cats.implicits._
+import core.db.Result
 import core.failures._
-import phoenix.models.cord.lineitems.CartLineItemAdjustment
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.ElasticsearchApi._
@@ -17,24 +16,29 @@ case class ItemsAmountOffer(discount: Int, search: Seq[ProductSearch])
     with NonEmptySearch
     with ItemsOffer {
 
-  val offerType: OfferType           = ItemsAmountOff
-  val adjustmentType: AdjustmentType = LineItemAdjustment
+  val offerType: OfferType = ItemsAmountOff
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (discount > 0) adjustInner(input)(search) else pureResult()
 
   def matchEither(input: DiscountInput)(
-      either: Either[Failures, Buckets]): Either[Failures, Seq[CartLineItemAdjustment]] =
+      either: Either[Failures, Buckets]): Either[Failures, Seq[OfferResult]] =
     either match {
       case Right(buckets) ⇒
         val matchedFormIds = buckets.filter(_.docCount > 0).map(_.key)
-        val adjustments = input.lineItems
+        val offerResults = input.lineItems
           .filter(data ⇒ matchedFormIds.contains(data.productForm.id.toString))
           .map { data ⇒
-            build(input, subtract(price(data), discount), data.lineItemReferenceNumber.some)
+            OfferResult(input,
+                        subtract(price(data), discount),
+                        data.lineItemReferenceNumber.some,
+                        offerType)
           }
 
-        Either.right(adjustments)
+        Either.right(offerResults)
       case _ ⇒ pureEither()
     }
 }

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemsPercentOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/ItemsPercentOffer.scala
@@ -1,9 +1,8 @@
 package phoenix.models.discount.offers
 
 import cats.implicits._
+import core.db.Result
 import core.failures._
-import phoenix.models.cord.lineitems.CartLineItemAdjustment
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.ElasticsearchApi._
@@ -17,24 +16,29 @@ case class ItemsPercentOffer(discount: Int, search: Seq[ProductSearch])
     with NonEmptySearch
     with ItemsOffer {
 
-  val offerType: OfferType           = ItemsPercentOff
-  val adjustmentType: AdjustmentType = LineItemAdjustment
+  val offerType: OfferType = ItemsPercentOff
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (discount > 0 && discount < 100) adjustInner(input)(search) else pureResult()
 
   def matchEither(input: DiscountInput)(
-      either: Either[Failures, Buckets]): Either[Failures, Seq[CartLineItemAdjustment]] =
+      either: Either[Failures, Buckets]): Either[Failures, Seq[OfferResult]] =
     either match {
       case Right(buckets) ⇒
         val matchedFormIds = buckets.filter(_.docCount > 0).map(_.key)
-        val adjustments = input.lineItems
+        val offerResults = input.lineItems
           .filter(data ⇒ matchedFormIds.contains(data.productForm.id.toString))
           .map { data ⇒
-            build(input, subtract(price(data), discount), data.lineItemReferenceNumber.some)
+            OfferResult(input,
+                        subtract(price(data), discount),
+                        data.lineItemReferenceNumber.some,
+                        offerType)
           }
 
-        Either.right(adjustments)
+        Either.right(offerResults)
       case _ ⇒ pureEither()
     }
 }

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/OfferList.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/OfferList.scala
@@ -2,7 +2,6 @@ package phoenix.models.discount.offers
 
 import cats.implicits._
 import core.db._
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
 import phoenix.models.discount.DiscountInput
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.aliases._
@@ -10,10 +9,12 @@ import phoenix.utils.apis.Apis
 
 case class OfferList(offers: Seq[Offer]) extends Offer {
 
-  val offerType: OfferType           = ListCombinator
-  val adjustmentType: AdjustmentType = Combinator
+  val offerType: OfferType = ListCombinator
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     Result.seqCollectFailures(offers.map(_.adjust(input)).toList).map(_.flatten)
 
 }

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/OrderAmountOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/OrderAmountOffer.scala
@@ -1,6 +1,6 @@
 package phoenix.models.discount.offers
 
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
+import core.db.Result
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.aliases._
@@ -8,10 +8,12 @@ import phoenix.utils.apis.Apis
 
 case class OrderAmountOffer(discount: Int) extends Offer with AmountOffer {
 
-  val offerType: OfferType           = OrderAmountOff
-  val adjustmentType: AdjustmentType = OrderAdjustment
+  val offerType: OfferType = OrderAmountOff
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (discount > 0)
       buildResult(input, subtract(input.eligibleForDiscountSubtotal, discount))
     else

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/OrderPercentOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/OrderPercentOffer.scala
@@ -1,6 +1,6 @@
 package phoenix.models.discount.offers
 
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
+import core.db.Result
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.aliases._
@@ -8,10 +8,12 @@ import phoenix.utils.apis.Apis
 
 case class OrderPercentOffer(discount: Int) extends Offer with PercentOffer {
 
-  val offerType: OfferType           = OrderPercentOff
-  val adjustmentType: AdjustmentType = OrderAdjustment
+  val offerType: OfferType = OrderPercentOff
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (discount > 0 && discount < 100)
       buildResult(input, subtract(input.eligibleForDiscountSubtotal, discount))
     else

--- a/phoenix-scala/phoenix/app/phoenix/models/discount/offers/SetPriceOffer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/discount/offers/SetPriceOffer.scala
@@ -1,9 +1,8 @@
 package phoenix.models.discount.offers
 
 import cats.implicits._
+import core.db.Result
 import core.failures._
-import phoenix.models.cord.lineitems.CartLineItemAdjustment
-import phoenix.models.cord.lineitems.CartLineItemAdjustment._
 import phoenix.models.discount._
 import phoenix.models.discount.offers.Offer.OfferResult
 import phoenix.utils.ElasticsearchApi._
@@ -16,14 +15,16 @@ case class SetPriceOffer(setPrice: Int, numUnits: Int, search: Seq[ProductSearch
     with NonEmptySearch
     with ItemsOffer {
 
-  val offerType: OfferType           = SetPrice
-  val adjustmentType: AdjustmentType = LineItemAdjustment
+  val offerType: OfferType = SetPrice
 
-  def adjust(input: DiscountInput)(implicit db: DB, ec: EC, apis: Apis, au: AU): OfferResult =
+  def adjust(input: DiscountInput)(implicit db: DB,
+                                   ec: EC,
+                                   apis: Apis,
+                                   au: AU): Result[Seq[OfferResult]] =
     if (setPrice > 0 && numUnits < 100) adjustInner(input)(search) else pureResult()
 
   def matchEither(input: DiscountInput)(
-      xor: Either[Failures, Buckets]): Either[Failures, Seq[CartLineItemAdjustment]] =
+      xor: Either[Failures, Buckets]): Either[Failures, Seq[OfferResult]] =
     xor match {
       case Right(buckets) ⇒
         val matchedFormIds = buckets.filter(_.docCount > 0).map(_.key)
@@ -31,7 +32,10 @@ case class SetPriceOffer(setPrice: Int, numUnits: Int, search: Seq[ProductSearch
           .filter(data ⇒ matchedFormIds.contains(data.productForm.id.toString))
           .take(numUnits)
           .map { data ⇒
-            build(input, subtract(price(data), setPrice), data.lineItemReferenceNumber.some)
+            OfferResult(input,
+                        subtract(price(data), setPrice),
+                        data.lineItemReferenceNumber.some,
+                        offerType)
           }
 
         Either.right(adjustments)

--- a/phoenix-scala/phoenix/app/phoenix/services/carts/CartPromotionUpdater.scala
+++ b/phoenix-scala/phoenix/app/phoenix/services/carts/CartPromotionUpdater.scala
@@ -2,6 +2,7 @@ package phoenix.services.carts
 
 import cats._
 import cats.implicits._
+import core.db._
 import core.failures.Failures
 import objectframework.models._
 import org.json4s.JsonAST._
@@ -32,7 +33,6 @@ import phoenix.utils.JsonFormatters
 import phoenix.utils.aliases._
 import phoenix.utils.apis.Apis
 import slick.jdbc.PostgresProfile.api._
-import core.db._
 
 object CartPromotionUpdater {
 
@@ -285,7 +285,7 @@ object CartPromotionUpdater {
       shipTotal      ← * <~ CartTotaler.shippingTotal(cart)
       cartWithTotalsUpdated = cart.copy(subTotal = subTotal, shippingTotal = shipTotal)
       input                 = DiscountInput(promo, cartWithTotalsUpdated, lineItems, shippingMethod)
-      _           ← * <~ qualifier.check(input)
-      adjustments ← * <~ offer.adjust(input)
-    } yield adjustments
+      _            ← * <~ qualifier.check(input)
+      offerResults ← * <~ offer.adjust(input)
+    } yield offerResults.map(CartLineItemAdjustment.fromOfferResult)
 }


### PR DESCRIPTION
To be able to move promos/discounts in their own submodule, we need to get rid of cart dependencies. This PR makes `CartLineItemAdjustment` know how to build itself from `OfferResult`, not the other way around.