### PR TITLE
Return rawQuery

### DIFF
--- a/ashes/src/modules/live-search/searches.js
+++ b/ashes/src/modules/live-search/searches.js
@@ -6,6 +6,7 @@ import Api from '../../lib/api';
 import SearchTerm from '../../paragons/search-term';
 import { createNsAction } from './../utils';
 import makeAssociations from './searches-associations';
+import { toQuery } from '../../elastic/common';
 
 const emptyState = {
   isDirty: false,
@@ -93,6 +94,7 @@ export default function makeSearches(namespace, dataActions, searchTerms, scope,
       title: search.title,
       query: search.query,
       scope: scope,
+      rawQuery: toQuery(search.query),
     };
 
     return dispatch => {
@@ -120,6 +122,7 @@ export default function makeSearches(namespace, dataActions, searchTerms, scope,
       title: search.title,
       query: search.query,
       scope: scope,
+      rawQuery: toQuery(search.query),
     };
 
     return dispatch => {


### PR DESCRIPTION
Return `rawQuery` for searches
Fixes the issue where a search couldn't be saved