### PR TITLE
Using prepared statements in user_verifier class

### DIFF
--- a/isaac/CMakeLists.txt
+++ b/isaac/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FindPkgConfig)
 #setup boost
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost COMPONENTS system program_options filesystem regex iostreams thread serialization REQUIRED)
+find_package(Boost COMPONENTS system program_options filesystem regex iostreams thread serialization context REQUIRED)
 link_directories(${Boost_LIBRARY_DIRS})
 include_directories(
     ${Boost_INCLUDE_DIRS})
@@ -33,6 +33,7 @@ set(MISC_LIBRARIES
     gflags
     botan-1.10
     libdouble-conversion.a
-    pqxx)
+    pqxx
+    dl)
 
 add_subdirectory(src)

--- a/isaac/src/db/user_verifier.hpp
+++ b/isaac/src/db/user_verifier.hpp
@@ -14,7 +14,7 @@ namespace isaac
         class user_verifier
         {
             public:
-                user_verifier(pqxx::connection& c) : _c{c} {}
+                user_verifier(pqxx::connection& c);
 
             public:
                 bool valid_user(std::size_t id, int ratchet);

--- a/isaac/src/isaac/CMakeLists.txt
+++ b/isaac/src/isaac/CMakeLists.txt
@@ -16,8 +16,9 @@ target_link_libraries(
     isaac_service
     isaac_db
     isaac_util
-    ${Boost_LIBRARIES}
-    ${MISC_LIBRARIES})
+    ${MISC_LIBRARIES}
+    ${Boost_LIBRARIES})
+
 
 add_dependencies(
     isaac 


### PR DESCRIPTION
Purpose of this commit is to use prepared statements instead of bare SQL in isaac. This should protect against SQL injection attacks and make isaac faster, because prepared statments perform sql parsing stage only once per application lifetime.