### PR TITLE
Extra logging for data import.

### DIFF
--- a/data-import/src/main.py
+++ b/data-import/src/main.py
@@ -156,13 +156,18 @@ class Phoenix:
         return code, json.loads(response.read().decode('utf-8'))
 
     def do_login(self):
+        print("logging in: host:",self.login_endpoint(), "user:", self.user, "organization:", self.org)
         payload = json.dumps({'email': self.user, 'password': self.password, 'org': self.org}).encode()
         context = ssl.create_default_context()
         context.check_hostname = False
-        req = urllib.request.Request(self.login_endpoint(), payload)
+        req = urllib.request.Request(self.login_endpoint(), payload, method='POST')
         req.add_header('Content-Type', 'application/json')
 
-        response = urllib.request.urlopen(req, context=context)
+        try:
+            response = urllib.request.urlopen(req, context=context)
+        except urllib.error.URLError as err:
+            print("Cannot connect to ", self.login_endpoint(), err)
+            raise
 
         content = json.loads(response.read().decode('utf-8'))
         self.jwt = dict(response.info())['Jwt']


### PR DESCRIPTION
Data import sometimes fails with following error:

```
fatal: [10.240.0.50]: FAILED! => {
  "changed": true,
  "cmd": [
    "docker",
    "run",
    "-d=false",
    "--env-file",
    "/data_import/.env.taxonomies",
    "-v",
    "/data_import:/data-import/data",
    "--network",
    "host",
    "docker-stage.foxcommerce.com:5000/data-import:master"
  ],
  "delta": "0:00:01.232529",
  "end": "2017-05-30 14:37:54.180491",
  "failed": true,
  "rc": 1,
  "start": "2017-05-30 14:37:52.947962",
  "stderr": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 1318, in do_open\n    encode_chunked=req.has_header('Transfer-encoding'))\n  File \"/usr/local/lib/python3.6/http/client.py\", line 1239, in request\n    self._send_request(method, url, body, headers, encode_chunked)\n  File \"/usr/local/lib/python3.6/http/client.py\", line 1285, in _send_request\n    self.endheaders(body, encode_chunked=encode_chunked)\n  File \"/usr/local/lib/python3.6/http/client.py\", line 1234, in endheaders\n    self._send_output(message_body, encode_chunked=encode_chunked)\n  File \"/usr/local/lib/python3.6/http/client.py\", line 1026, in _send_output\n    self.send(msg)\n  File \"/usr/local/lib/python3.6/http/client.py\", line 964, in send\n    self.connect()\n  File \"/usr/local/lib/python3.6/http/client.py\", line 1392, in connect\n    super().connect()\n  File \"/usr/local/lib/python3.6/http/client.py\", line 936, in connect\n    (self.host,self.port), self.timeout, self.source_address)\n  File \"/usr/local/lib/python3.6/socket.py\", line 722, in create_connection\n    raise err\n  File \"/usr/local/lib/python3.6/socket.py\", line 713, in create_connection\n    sock.connect(sa)\nConnectionRefusedError: [Errno 111] Connection refused\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"src/main.py\", line 465, in <module>\n    main()\n  File \"src/main.py\", line 430, in main\n    import_taxonomies(p, options.input[0], options.adidas)\n  File \"src/main.py\", line 330, in import_taxonomies\n    if p.ensure_logged_in():\n  File \"src/main.py\", line 133, in ensure_logged_in\n    return self.do_login()\n  File \"src/main.py\", line 165, in do_login\n    response = urllib.request.urlopen(req, context=context)\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 223, in urlopen\n    return opener.open(url, data, timeout)\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 526, in open\n    response = self._open(req, data)\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 544, in _open\n    '_open', req)\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 504, in _call_chain\n    result = func(*args)\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 1361, in https_open\n    context=self._context, check_hostname=self._check_hostname)\n  File \"/usr/local/lib/python3.6/urllib/request.py\", line 1320, in do_open\n    raise URLError(err)\nurllib.error.URLError: <urlopen error [Errno 111] Connection refused>",
  "stdout": "HOST:  appliance-10-240-0-50.foxcommerce.com\nCMD:  taxonomies\nMAX:  100\nImporting taxonomies",
  "stdout_lines": [
    "HOST:  appliance-10-240-0-50.foxcommerce.com",
    "CMD:  taxonomies",
    "MAX:  100",
    "Importing taxonomies"
  ],
  "warnings": []
}
```

This PR adds additional logging `print` statements.