### PR TITLE
Do not return default check for order shipping address

### DIFF
--- a/phoenix-scala/phoenix/app/phoenix/models/cord/OrderShippingAddress.scala
+++ b/phoenix-scala/phoenix/app/phoenix/models/cord/OrderShippingAddress.scala
@@ -72,9 +72,8 @@ class OrderShippingAddresses(tag: Tag)
   def * =
     (id, cordRef, regionId, name, address1, address2, city, zip, phoneNumber, createdAt, updatedAt) <> ((OrderShippingAddress.apply _).tupled, OrderShippingAddress.unapply)
 
-  def address = foreignKey(Addresses.tableName, id, Addresses)(_.id)
-  def order   = foreignKey(Carts.tableName, cordRef, Carts)(_.referenceNumber)
-  def region  = foreignKey(Regions.tableName, regionId, Regions)(_.id)
+  def order  = foreignKey(Carts.tableName, cordRef, Carts)(_.referenceNumber)
+  def region = foreignKey(Regions.tableName, regionId, Regions)(_.id)
 }
 
 object OrderShippingAddresses

--- a/phoenix-scala/phoenix/app/phoenix/responses/AddressResponse.scala
+++ b/phoenix-scala/phoenix/app/phoenix/responses/AddressResponse.scala
@@ -61,16 +61,7 @@ object AddressResponse {
   def buildMulti(records: Seq[(Address, Region)]): Seq[AddressResponse] =
     records.map((build _).tupled)
 
-  def buildShipping(records: Seq[(Address, OrderShippingAddress, Region)]): Seq[AddressResponse] = {
-    records.map {
-      case (address, shippingAddress, region) ⇒
-        build(address, region)
-    }
-  }
-
-  def buildOneShipping(address: OrderShippingAddress,
-                       region: Region,
-                       isDefault: Boolean = false): AddressResponse = {
+  def buildFromOrder(address: OrderShippingAddress, region: Region): AddressResponse = {
     AddressResponse(id = address.id,
                     region = region,
                     name = address.name,
@@ -78,7 +69,7 @@ object AddressResponse {
                     address2 = address.address2,
                     city = address.city,
                     zip = address.zip,
-                    isDefault = Some(isDefault),
+                    isDefault = None,
                     phoneNumber = address.phoneNumber,
                     deletedAt = None)
   }
@@ -94,7 +85,7 @@ object AddressResponse {
       (addresses, regions) = fullAddress.unzip
       response ← * <~ ((addresses.headOption, regions.headOption) match {
                       case (Some(address), Some(region)) ⇒
-                        DbResultT.good(buildOneShipping(address, region))
+                        DbResultT.good(buildFromOrder(address, region))
                       case (None, _) ⇒
                         DbResultT.failure(NotFoundFailure404(
                                 s"No addresses found for order with refNum=$cordRef"))

--- a/phoenix-scala/phoenix/app/phoenix/services/carts/CartShippingAddressUpdater.scala
+++ b/phoenix-scala/phoenix/app/phoenix/services/carts/CartShippingAddressUpdater.scala
@@ -7,7 +7,7 @@ import phoenix.models.cord._
 import phoenix.models.location.Addresses.scope._
 import phoenix.models.location._
 import phoenix.payloads.AddressPayloads._
-import phoenix.responses.AddressResponse.buildOneShipping
+import phoenix.responses.AddressResponse.buildFromOrder
 import phoenix.responses.TheResponse
 import phoenix.responses.cord.CartResponse
 import phoenix.services.{CartValidator, LogActivity}
@@ -41,7 +41,7 @@ object CartShippingAddressUpdater {
       validated   ← * <~ CartValidator(cart).validate()
       response    ← * <~ CartResponse.buildRefreshed(cart)
       _ ← * <~ LogActivity()
-           .orderShippingAddressAdded(originator, response, buildOneShipping(shipAddress, region))
+           .orderShippingAddressAdded(originator, response, buildFromOrder(shipAddress, region))
     } yield TheResponse.validated(response, validated)
 
   def createShippingAddressFromPayload(originator: User,
@@ -60,7 +60,7 @@ object CartShippingAddressUpdater {
       validated   ← * <~ CartValidator(cart).validate()
       response    ← * <~ CartResponse.buildRefreshed(cart)
       _ ← * <~ LogActivity()
-           .orderShippingAddressAdded(originator, response, buildOneShipping(shipAddress, region))
+           .orderShippingAddressAdded(originator, response, buildFromOrder(shipAddress, region))
     } yield TheResponse.validated(response, validated)
 
   def updateShippingAddressFromPayload(originator: User,
@@ -78,9 +78,8 @@ object CartShippingAddressUpdater {
       _         ← * <~ OrderShippingAddresses.update(shipAddress, patch)
       validated ← * <~ CartValidator(cart).validate()
       response  ← * <~ CartResponse.buildRefreshed(cart)
-      _ ← * <~ LogActivity().orderShippingAddressUpdated(originator,
-                                                         response,
-                                                         buildOneShipping(shipAddress, region))
+      _ ← * <~ LogActivity()
+           .orderShippingAddressUpdated(originator, response, buildFromOrder(shipAddress, region))
     } yield TheResponse.validated(response, validated)
 
   def removeShippingAddress(originator: User, refNum: Option[String] = None)(
@@ -95,8 +94,7 @@ object CartShippingAddressUpdater {
       _           ← * <~ OrderShippingAddresses.findById(shipAddress.id).delete
       validated   ← * <~ CartValidator(cart).validate()
       fullOrder   ← * <~ CartResponse.buildRefreshed(cart)
-      _ ← * <~ LogActivity().orderShippingAddressDeleted(originator,
-                                                         fullOrder,
-                                                         buildOneShipping(shipAddress, region))
+      _ ← * <~ LogActivity()
+           .orderShippingAddressDeleted(originator, fullOrder, buildFromOrder(shipAddress, region))
     } yield TheResponse.validated(fullOrder, validated)
 }

--- a/phoenix-scala/phoenix/test/integration/CheckoutIntegrationTest.scala
+++ b/phoenix-scala/phoenix/test/integration/CheckoutIntegrationTest.scala
@@ -88,7 +88,16 @@ class CheckoutIntegrationTest
             'id (creditCard.id),
             'type (PaymentMethod.CreditCard)
         )
-        order.shippingAddress.id must === (address.id)
+
+        val orderShippingAddress =
+          OrderShippingAddresses.findOneById(order.shippingAddress.id).gimme.value
+        val expectedAddressResponse = AddressResponse.buildFromOrder(
+            orderShippingAddress,
+            order.shippingAddress.region
+        )
+        expectedAddressResponse must === (
+            address.copy(id = expectedAddressResponse.id, isDefault = None))
+        order.shippingAddress must === (expectedAddressResponse)
         order.shippingMethod.id must === (shipMethod.id)
       }
     }


### PR DESCRIPTION
"Fixes" #2043. `isDefault` for order shipping addresses is now removed from the response (so it's neither `true` nor `false`). Also, I've put additional test check as it's in @michalrus [PR](#1988).

Unfortunately I cannot join on `addresses` table to get real value of this field, as `order_shipping_addresses` does not reference `addresses` table (Slick's foreign key annotation was a lie :crying_cat_face:). 
I could add `address_id` or actually reuse `id` from `addresses` table as `id` in `order_shipping_addresses`, but we have patch endpoint in `carts`/`orders` that may override any field in `order_shipping_addresses` row, thus such reference would not make any sense currently.
I guess, it's to decide if current behavior is desirable, or it's some overlooking. /cc @anna-zzz 