### PR TITLE
Fixes failed ApplePayIntegrationTest

### DIFF
--- a/phoenix-scala/phoenix/test/integration/ApplePayIntegrationTest.scala
+++ b/phoenix-scala/phoenix/test/integration/ApplePayIntegrationTest.scala
@@ -121,8 +121,10 @@ class ApplePayIntegrationTest
     val apToken           = "tok_1A9YBQJVm1XvTUrO3V8caBvF"
     val customerLoginData = TestLoginData(email = "test@bar.com", password = "pwd")
     val customer = customersApi
-      .create(CreateCustomerPayload(email = customerLoginData.email,
-                                    password = customerLoginData.password.some))
+      .create(
+          CreateCustomerPayload(email = customerLoginData.email,
+                                name = "Test customer".some,
+                                password = customerLoginData.password.some))
       .as[CustomerResponse.Root]
 
     val cart = cartsApi.create(CreateCart(customerId = customer.id.some)).as[CartResponse]


### PR DESCRIPTION
Newly introduced constraint for customer name  in `V4.122__create_customer_items_search_view.sql`

has resulted in ApplePayIntegrationTest failing with

```
 PL/pgSQL function insert_customer_items_search_view_from_line_items_fn() line 3 at SQL statement  Call getNextException to see other errors in the batch., Batch entry 0 insert into "order_line_items" ("reference_number","cord_ref","sku_id","sku_shadow_id","state","attributes")  values ('4e7a9b41-379a-43d2-757b-24ca1badd79e','BR10001',1,2,'pending',NULL) was aborted: ERROR: null value in column "customer_name" violates not-null constraint
[info]     Подробности: Failing row contains (1, 1.2, 2, null, test@bar.com, testprod_2474-sku_TEZL, Testprod_2474-sku_TEZL, 2155, BR10001, 2017-06-05T18:21:04.833Z, pending, null).
[info]     Где: SQL statement "insert into customer_items_view
[info]       select

```

Currently `CreateCustomerPayload` has a name as Optional, so we have an easy way to get things broken.

@jmataya WDYT maybe we should make it mandatory there, given that new constraint?

I'd like to address that change (if it sounds) in a separate PR anyway.
