### PR TITLE
Remove prepare commit msg hook

### DIFF
--- a/git-hooks/prepare-commit-msg
+++ b/git-hooks/prepare-commit-msg
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-sed -i "1s/$/\n\n[skip ci]/" "$1" || exit 0


### PR DESCRIPTION
Sorry, @michalrus!

Yes, it adds a handy line for buildkite, but it keeps adding it when I'm
amending or rebasing which can turn pretty annoying.
I decided to remove it.