### PR TITLE
Update product_sku_links_view on insert of product_variant_link

### DIFF
--- a/phoenix-scala/sql/R__product_sku_links_view_functions.sql
+++ b/phoenix-scala/sql/R__product_sku_links_view_functions.sql
@@ -69,6 +69,8 @@ begin
       inner join product_sku_links as link on link.left_id = p.id
       inner join skus as sku on (sku.id = link.right_id)
       where sku.id = new.id;
+    when 'product_variant_links' then
+      product_ids := array_agg(new.left_id);
     when 'variant_value_sku_links' then
       select array_agg(p.id) into product_ids
       from products as p
@@ -94,3 +96,9 @@ begin
     return null;
 end;
 $$ language plpgsql;
+
+drop trigger if exists update_product_sku_links_view_on_product_variants on product_variant_links;
+create trigger update_product_sku_links_view_on_product_variants
+  after update or insert on product_variant_links
+  for each row
+  execute procedure update_product_sku_links_view_from_products_and_deps_fn();


### PR DESCRIPTION
This action runs _after_ the variant_variant_value_link is created, so we need this hook when a product is initially created.