### PR TITLE
Rollback customer name `not null` constraint

### DIFF
--- a/phoenix-scala/phoenix/app/phoenix/payloads/CustomerPayloads.scala
+++ b/phoenix-scala/phoenix/app/phoenix/payloads/CustomerPayloads.scala
@@ -8,11 +8,12 @@ import core.utils.Validation._
 
 object CustomerPayloads {
 
-  case class CreateCustomerPayload(email: String,
-                                   name: Option[String] = None,
-                                   password: Option[String] = None,
-                                   isGuest: Option[Boolean] = Some(false),
-                                   scope: Option[String] = None)
+  case class CreateCustomerPayload(
+      email: String,
+      name: Option[String] = None, // @aafa FIXME: customer name should be non optional here
+      password: Option[String] = None,
+      isGuest: Option[Boolean] = Some(false),
+      scope: Option[String] = None)
 
   case class UpdateCustomerPayload(name: Option[String] = None,
                                    email: Option[String] = None,

--- a/phoenix-scala/phoenix/test/integration/ApplePayIntegrationTest.scala
+++ b/phoenix-scala/phoenix/test/integration/ApplePayIntegrationTest.scala
@@ -143,8 +143,7 @@ class ApplePayIntegrationTest
     val customerLoginData = TestLoginData(email = "test@bar.com", password = "pwd")
     val customer = customersApi
       .create(
-        CreateCustomerPayload(email = customerLoginData.email,
-                              name = "Test customer".some,
+        CreateCustomerPayload(email = customerLoginData.email, // @aafa FIXME: provide customer name
                               password = customerLoginData.password.some))
       .as[CustomerResponse.Root]
 

--- a/phoenix-scala/sql/V5.20170609210604__rolback_customer_name_constaint.sql
+++ b/phoenix-scala/sql/V5.20170609210604__rolback_customer_name_constaint.sql
@@ -1,0 +1,1 @@
+alter table customer_items_view alter column customer_name drop not null;


### PR DESCRIPTION
- drops 'not null' for `customer_items_view.customer_name`
- a test that explicitly creates a customer with empty name and goes through checkout