### PR TITLE
ArchivedAt fields on links should default to null

### DIFF
--- a/phoenix-scala/sql/V5.20170531181303__add_archived_at_to_links.sql
+++ b/phoenix-scala/sql/V5.20170531181303__add_archived_at_to_links.sql
@@ -1,9 +1,9 @@
-alter table album_image_links add column archived_at generic_timestamp;
-alter table product_album_links add column archived_at generic_timestamp;
-alter table product_sku_links add column archived_at generic_timestamp;
-alter table product_variant_links add column archived_at generic_timestamp;
-alter table promotion_discount_links add column archived_at generic_timestamp;
-alter table sku_album_links add column archived_at generic_timestamp;
-alter table variant_variant_value_links add column archived_at generic_timestamp;
-alter table variant_value_sku_links add column archived_at generic_timestamp;
+alter table album_image_links add column archived_at generic_timestamp_null;
+alter table product_album_links add column archived_at generic_timestamp_null;
+alter table product_sku_links add column archived_at generic_timestamp_null;
+alter table product_variant_links add column archived_at generic_timestamp_null;
+alter table promotion_discount_links add column archived_at generic_timestamp_null;
+alter table sku_album_links add column archived_at generic_timestamp_null;
+alter table variant_variant_value_links add column archived_at generic_timestamp_null;
+alter table variant_value_sku_links add column archived_at generic_timestamp_null;
 


### PR DESCRIPTION
Normally, we don't update existing migrations, but we don't want the old
migration to be run against any production environment.