### PR TITLE
Set ITs free from hardcoded locale-dependent keywords

### DIFF
--- a/phoenix-scala/phoenix/test/integration/DbResultSequenceIntegrationTest.scala
+++ b/phoenix-scala/phoenix/test/integration/DbResultSequenceIntegrationTest.scala
@@ -40,11 +40,13 @@ class DbResultSequenceIntegrationTest extends IntegrationTestBase {
       }
       val cool: DbResultT[List[User]] = DbResultT.seqCollectFailures(sux)
 
-      val failures = cool.gimmeFailures
-      val expectedFailure = DatabaseFailure(
-        "ERROR: duplicate key value violates unique constraint \"users_account_idx\"\n" +
-          s"  Detail: Key (account_id)=(${account.id}) already exists.")
-      failures must === (NonEmptyList.fromList(List.fill[Failure](numTries - 1)(expectedFailure)).value)
+      val failures        = cool.gimmeFailures
+      val expectedFailure = DatabaseFailure(s"Key (account_id)=(${account.id}) already exists.")
+
+      failures.size must === (numTries - 1)
+      failures
+        .map(_.description.contains(expectedFailure.description))
+        .forall(_ == true) must === (true)
 
       Users.gimme.onlyElement.accountId must === (account.id)
     }

--- a/phoenix-scala/phoenix/test/integration/utils/ModelIntegrationTest.scala
+++ b/phoenix-scala/phoenix/test/integration/utils/ModelIntegrationTest.scala
@@ -1,6 +1,6 @@
 package utils
 
-import core.failures.{DatabaseFailure, GeneralFailure}
+import core.failures.{DatabaseFailure, Failures, GeneralFailure}
 import phoenix.failures.StateTransitionNotAllowed
 import phoenix.models.account._
 import phoenix.models.cord.Order.Shipped
@@ -38,7 +38,7 @@ class ModelIntegrationTest extends IntegrationTestBase with TestObjectContext wi
     "catches exceptions from DB" in {
       val account = Accounts.create(Account()).gimme
 
-      val result = (for {
+      val result: Failures = (for {
         customer ← * <~ Users.create(Factories.customer.copy(accountId = account.id))
         scope    ← * <~ Scopes.forOrganization(TENANT)
         _ ← * <~ CustomersData.create(
@@ -46,10 +46,9 @@ class ModelIntegrationTest extends IntegrationTestBase with TestObjectContext wi
         _       ← * <~ Addresses.create(Factories.address.copy(accountId = customer.accountId))
         copycat ← * <~ Addresses.create(Factories.address.copy(accountId = customer.accountId))
       } yield copycat).gimmeTxnFailures
-      result must === (
-        DatabaseFailure(
-          "ERROR: duplicate key value violates unique constraint \"address_shipping_default_idx\"\n" +
-            s"  Detail: Key (account_id, is_default_shipping)=(${account.id}, t) already exists.").single)
+
+      result.toList.onlyElement.description contains
+        s"Key (account_id, is_default_shipping)=(${account.id}, t) already exists." must === (true)
     }
 
     "fails if model already exists" in {


### PR DESCRIPTION
Set ITs free from hardcoded locale-dependent keywords, to eradicate false-failures like this one

```
[info]   NonEmptyList(DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Подробности: Key (account_id)=(91035433) already exists.), DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Подробности: Key (account_id)=(91035433) already exists.), DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Подробности: Key (account_id)=(91035433) already exists.), DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Подробности: Key (account_id)=(91035433) already exists.)) did not equal NonEmptyList(DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Detail: Key (account_id)=(91035433) already exists.), DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Detail: Key (account_id)=(91035433) already exists.), DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Detail: Key (account_id)=(91035433) already exists.), DatabaseFailure(ERROR: duplicate key value violates unique constraint "users_account_idx"
[info]     Detail: Key (account_id)=(91035433) already exists.)) (DbResultSequenceIntegrationTest.scala:47)
```