### PR TITLE
Distinct failures 

### DIFF
--- a/phoenix-scala/phoenix/app/phoenix/failures/OrderFailures.scala
+++ b/phoenix-scala/phoenix/app/phoenix/failures/OrderFailures.scala
@@ -16,7 +16,7 @@ object OrderFailures {
   }
 
   case object OnlyOneExternalPaymentIsAllowed extends Failure {
-    def description: String = "Only one external payment is allowed!"
+    def description: String = "Only one payment method is allowed (credit card or apple pay)!"
   }
 
   case object NoExternalPaymentsIsProvided extends Failure {

--- a/phoenix-scala/phoenix/app/phoenix/utils/http/Http.scala
+++ b/phoenix-scala/phoenix/app/phoenix/utils/http/Http.scala
@@ -91,7 +91,7 @@ object Http {
       List(`Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" → fileName))))(source)
 
   def renderFailure(failures: Failures, statusCode: ClientError = BadRequest): HttpResponse = {
-    val failuresList = failures.toList
+    val failuresList = failures.toList.distinct
     val notFound     = failuresList.collectFirst { case f: NotFoundFailure404 ⇒ f }
     notFound.fold(HttpResponse(statusCode, entity = jsonEntity("errors" → failuresList.map(_.description)))) {
       nf ⇒

--- a/phoenix-scala/phoenix/test/integration/ApplePayIntegrationTest.scala
+++ b/phoenix-scala/phoenix/test/integration/ApplePayIntegrationTest.scala
@@ -114,6 +114,8 @@ class ApplePayIntegrationTest
         val cc = storefrontPaymentsApi.creditCards.create(ccPayload).as[CreditCardsResponse.Root]
         cartsApi(refNum).payments.creditCard.add(CreditCardPayment(cc.id)).mustBeOk()
 
+        // additional check to make sure only one failure has arrived
+        cartsApi(refNum).checkout().errors.onlyElement must === (OnlyOneExternalPaymentIsAllowed.description)
         cartsApi(refNum).checkout().mustFailWith400(OnlyOneExternalPaymentIsAllowed)
       }
     }


### PR DESCRIPTION
coupled \w a friendly message for `OnlyOneExternalPaymentIsAllowed`

@michalrus this seems to be a quick fix, for now, WDYT?