### PR TITLE
Split line item updaters

### DIFF
--- a/phoenix-scala/phoenix/app/phoenix/routes/Customer.scala
+++ b/phoenix-scala/phoenix/app/phoenix/routes/Customer.scala
@@ -49,12 +49,12 @@ object Customer {
               } ~
               (post & path("line-items") & pathEnd & entity(as[Seq[UpdateLineItemsPayload]])) { reqItems ⇒
                 mutateOrFailures {
-                  LineItemUpdater.updateQuantitiesOnCustomersCart(auth.model, reqItems)
+                  CartLineItemUpdater.updateQuantitiesOnCustomersCart(auth.model, reqItems)
                 }
               } ~
               (patch & path("line-items") & pathEnd & entity(as[Seq[UpdateLineItemsPayload]])) { reqItems ⇒
                 mutateOrFailures {
-                  LineItemUpdater.addQuantitiesOnCustomersCart(auth.model, reqItems)
+                  CartLineItemUpdater.addQuantitiesOnCustomersCart(auth.model, reqItems)
                 }
               } ~
               (post & path("coupon" / Segment) & pathEnd) { code ⇒

--- a/phoenix-scala/phoenix/app/phoenix/routes/admin/CartRoutes.scala
+++ b/phoenix-scala/phoenix/app/phoenix/routes/admin/CartRoutes.scala
@@ -13,7 +13,8 @@ import phoenix.payloads.PaymentPayloads._
 import phoenix.payloads.UpdateShippingMethod
 import phoenix.services.Authenticator.AuthData
 import phoenix.services.carts._
-import phoenix.services.{Checkout, LineItemUpdater}
+import phoenix.services.orders.OrderLineItemUpdater
+import phoenix.services.Checkout
 import phoenix.utils.aliases._
 import phoenix.utils.apis.Apis
 import phoenix.utils.http.CustomDirectives._
@@ -58,18 +59,18 @@ object CartRoutes {
             pathPrefix("line-items") {
               (post & pathEnd & entity(as[Seq[UpdateLineItemsPayload]])) { reqItems ⇒
                 mutateOrFailures {
-                  LineItemUpdater.updateQuantitiesOnCart(auth.model, refNum, reqItems)
+                  CartLineItemUpdater.updateQuantitiesOnCart(auth.model, refNum, reqItems)
                 }
               } ~
               (patch & pathEnd & entity(as[Seq[UpdateLineItemsPayload]])) { reqItems ⇒
                 mutateOrFailures {
-                  LineItemUpdater.addQuantitiesOnCart(auth.model, refNum, reqItems)
+                  CartLineItemUpdater.addQuantitiesOnCart(auth.model, refNum, reqItems)
                 }
               } ~
               (patch & path("attributes") & pathEnd & entity(as[Seq[UpdateOrderLineItemsPayload]])) {
                 reqItems ⇒
                   mutateOrFailures {
-                    LineItemUpdater.updateOrderLineItems(auth.model, reqItems, refNum)
+                    OrderLineItemUpdater.updateOrderLineItems(auth.model, reqItems, refNum)
                   }
               }
             } ~

--- a/phoenix-scala/phoenix/app/phoenix/routes/admin/OrderRoutes.scala
+++ b/phoenix-scala/phoenix/app/phoenix/routes/admin/OrderRoutes.scala
@@ -15,7 +15,7 @@ import phoenix.payloads.UpdateShippingMethod
 import phoenix.services.Authenticator.AuthData
 import phoenix.services.carts._
 import phoenix.services.orders._
-import phoenix.services.{Checkout, LineItemUpdater}
+import phoenix.services.Checkout
 import phoenix.utils.aliases._
 import phoenix.utils.apis.Apis
 import phoenix.utils.http.CustomDirectives._
@@ -50,7 +50,7 @@ object OrderRoutes {
           pathPrefix("line-items") {
             (patch & pathEnd & entity(as[Seq[UpdateOrderLineItemsPayload]])) { reqItems ⇒
               mutateOrFailures {
-                LineItemUpdater.updateOrderLineItems(auth.model, reqItems, refNum)
+                OrderLineItemUpdater.updateOrderLineItems(auth.model, reqItems, refNum)
               }
             }
           } ~
@@ -58,7 +58,7 @@ object OrderRoutes {
           pathPrefix("order-line-items") {
             (patch & pathEnd & entity(as[Seq[UpdateOrderLineItemsPayload]])) { reqItems ⇒
               mutateOrFailures {
-                LineItemUpdater.updateOrderLineItems(auth.model, reqItems, refNum)
+                OrderLineItemUpdater.updateOrderLineItems(auth.model, reqItems, refNum)
               }
             }
           } ~
@@ -93,13 +93,13 @@ object OrderRoutes {
           // deprecated in favor of /carts route
           (post & path("line-items") & pathEnd & entity(as[Seq[UpdateLineItemsPayload]])) { reqItems ⇒
             mutateOrFailures {
-              LineItemUpdater.updateQuantitiesOnCart(auth.model, refNum, reqItems)
+              CartLineItemUpdater.updateQuantitiesOnCart(auth.model, refNum, reqItems)
             }
           } ~
           // deprecated in favor of /carts route
           (patch & path("line-items") & pathEnd & entity(as[Seq[UpdateLineItemsPayload]])) { reqItems ⇒
             mutateOrFailures {
-              LineItemUpdater.addQuantitiesOnCart(auth.model, refNum, reqItems)
+              CartLineItemUpdater.addQuantitiesOnCart(auth.model, refNum, reqItems)
             }
           } ~
           // deprecated in favor of /carts route

--- a/phoenix-scala/phoenix/app/phoenix/services/Checkout.scala
+++ b/phoenix-scala/phoenix/app/phoenix/services/Checkout.scala
@@ -158,7 +158,7 @@ object Checkout {
         }.toStream)
 
     def unstashItems(items: Seq[UpdateLineItemsPayload]): DbResultT[Unit] =
-      LineItemUpdater.updateQuantitiesOnCustomersCart(customer, items).void
+      CartLineItemUpdater.updateQuantitiesOnCustomersCart(customer, items).void
 
     for {
       cart ← * <~ CartQueries.findOrCreateCartByAccount(customer, ctx, admin)
@@ -167,7 +167,7 @@ object Checkout {
       scope      = Scope.current
 
       stashedItems ← * <~ stashItems(cart.referenceNumber)
-      _            ← * <~ LineItemUpdater.updateQuantitiesOnCustomersCart(customer, payload.items)
+      _            ← * <~ CartLineItemUpdater.updateQuantitiesOnCustomersCart(customer, payload.items)
 
       ccId ← * <~ CreditCards
               .findDefaultByAccountId(customerId)

--- a/phoenix-scala/phoenix/app/phoenix/services/LogActivity.scala
+++ b/phoenix-scala/phoenix/app/phoenix/services/LogActivity.scala
@@ -36,7 +36,7 @@ import phoenix.responses.SkuResponses.SkuResponse
 import phoenix.responses._
 import phoenix.responses.cord.{CartResponse, OrderResponse}
 import phoenix.responses.users.{CustomerResponse, UserResponse}
-import phoenix.services.LineItemUpdater.foldQuantityPayload
+import phoenix.services.carts.CartLineItemUpdater.foldQuantityPayload
 import phoenix.services.activity.AssignmentsTailored._
 import phoenix.services.activity.CartTailored._
 import phoenix.services.activity.CatalogTailored.{CatalogCreated, CatalogUpdated}

--- a/phoenix-scala/phoenix/app/phoenix/services/carts/CartQueries.scala
+++ b/phoenix-scala/phoenix/app/phoenix/services/carts/CartQueries.scala
@@ -7,7 +7,7 @@ import phoenix.models.account._
 import phoenix.models.cord._
 import phoenix.responses.TheResponse
 import phoenix.responses.cord.CartResponse
-import phoenix.services.{CordQueries, LineItemUpdater, LogActivity}
+import phoenix.services.{CordQueries, LogActivity}
 import phoenix.utils.aliases._
 import phoenix.utils.apis.Apis
 
@@ -20,7 +20,7 @@ object CartQueries extends CordQueries {
                               au: AU): DbResultT[TheResponse[CartResponse]] =
     for {
       cart ← * <~ Carts.mustFindByRefNum(refNum)
-      resp ← * <~ LineItemUpdater.runUpdates(cart, None) // FIXME: so costly… @michalrus
+      resp ← * <~ CartLineItemUpdater.runUpdates(cart, None) // FIXME: so costly… @michalrus
     } yield resp
 
   def findOneByUser(refNum: String, customer: User, grouped: Boolean = true)(
@@ -33,7 +33,7 @@ object CartQueries extends CordQueries {
       cart ← * <~ Carts
               .findByRefNumAndAccountId(refNum, customer.accountId)
               .mustFindOneOr(NotFoundFailure404(Carts, refNum))
-      resp ← * <~ LineItemUpdater.runUpdates(cart, None) // FIXME: so costly… @michalrus
+      resp ← * <~ CartLineItemUpdater.runUpdates(cart, None) // FIXME: so costly… @michalrus
     } yield resp
 
   def findOrCreateCartByAccount(customer: User, context: ObjectContext, admin: Option[User] = None)(
@@ -75,6 +75,6 @@ object CartQueries extends CordQueries {
               fullCart ← * <~ CartResponse.fromCart(cart, grouped, au.isGuest)
               _        ← * <~ LogActivity().cartCreated(admin, fullCart)
             } yield TheResponse(fullCart)
-            else LineItemUpdater.runUpdates(cart, None) // FIXME: so costly… @michalrus
+            else CartLineItemUpdater.runUpdates(cart, None) // FIXME: so costly… @michalrus
     } yield resp.result // FIXME: discarding warnings until we get rid of TheResponse completely @michalrus
 }

--- a/phoenix-scala/phoenix/app/phoenix/services/orders/OrderLineItemUpdater.scala
+++ b/phoenix-scala/phoenix/app/phoenix/services/orders/OrderLineItemUpdater.scala
@@ -1,0 +1,39 @@
+package phoenix.services.orders
+
+import cats.implicits._
+import core.db._
+import phoenix.failures.OrderFailures.OrderLineItemNotFound
+import phoenix.models.account.User
+import phoenix.models.cord.Orders
+import phoenix.models.cord.lineitems.OrderLineItems
+import phoenix.payloads.LineItemPayloads.UpdateOrderLineItemsPayload
+import phoenix.responses.cord.OrderResponse
+import phoenix.utils.aliases.{AC, OC}
+import phoenix.utils.apis.Apis
+import slick.jdbc.PostgresProfile.api._
+
+object OrderLineItemUpdater {
+
+  def updateOrderLineItems(
+      admin: User,
+      payload: Seq[UpdateOrderLineItemsPayload],
+      refNum: String)(implicit ec: EC, apis: Apis, db: DB, ac: AC, ctx: OC): DbResultT[OrderResponse] =
+    for {
+      _             ← * <~ runOrderLineItemUpdates(payload)
+      orderUpdated  ← * <~ Orders.mustFindByRefNum(refNum)
+      orderResponse ← * <~ OrderResponse.fromOrder(orderUpdated, grouped = true)
+    } yield orderResponse
+
+  private def runOrderLineItemUpdates(
+      payload: Seq[UpdateOrderLineItemsPayload])(implicit ec: EC, apis: Apis, db: DB, ac: AC, ctx: OC) =
+    DbResultT.seqCollectFailures(payload.map { updatePayload ⇒
+      for {
+        orderLineItem ← * <~ OrderLineItems
+                         .filter(_.referenceNumber === updatePayload.referenceNumber)
+                         .mustFindOneOr(OrderLineItemNotFound(updatePayload.referenceNumber))
+        patch = orderLineItem.copy(state = updatePayload.state, attributes = updatePayload.attributes)
+        updatedItem ← * <~ OrderLineItems.update(orderLineItem, patch)
+      } yield updatedItem
+    }.toList)
+
+}

--- a/phoenix-scala/phoenix/test/integration/services/CheckoutTest.scala
+++ b/phoenix-scala/phoenix/test/integration/services/CheckoutTest.scala
@@ -21,7 +21,7 @@ import phoenix.models.payment.storecredit._
 import phoenix.models.product.{Mvp, SimpleContext}
 import phoenix.models.shipping.ShippingMethods
 import phoenix.payloads.LineItemPayloads.UpdateLineItemsPayload
-import phoenix.services.{CartValidation, CartValidatorResponse, Checkout, LineItemUpdater}
+import phoenix.services.{CartValidation, CartValidatorResponse, Checkout}
 import phoenix.utils.aliases._
 import phoenix.utils.apis.Apis
 import phoenix.utils.seeds.Factories
@@ -30,6 +30,8 @@ import testutils._
 import testutils.fixtures.BakedFixtures
 import core.db._
 import core.utils.Money._
+import phoenix.services.carts.CartLineItemUpdater
+
 import scala.concurrent.Future
 
 class CheckoutTest
@@ -167,7 +169,9 @@ class CheckoutTest
 
             cart ← * <~ Carts.create(Cart(accountId = customer.accountId, scope = Scope.current))
 
-            _ ← * <~ LineItemUpdater.updateQuantitiesOnCart(storeAdmin, cart.refNum, lineItemPayload(total))
+            _ ← * <~ CartLineItemUpdater.updateQuantitiesOnCart(storeAdmin,
+                                                                cart.refNum,
+                                                                lineItemPayload(total))
 
             c ← * <~ Carts.refresh(cart)
 

--- a/phoenix-scala/phoenix/test/integration/services/LineItemUpdaterTest.scala
+++ b/phoenix-scala/phoenix/test/integration/services/LineItemUpdaterTest.scala
@@ -4,12 +4,12 @@ import objectframework.models.{ObjectContext, ObjectContexts}
 import phoenix.models.cord.lineitems._
 import phoenix.models.product.{Mvp, SimpleContext, SimpleProductData}
 import phoenix.payloads.LineItemPayloads.{UpdateLineItemsPayload ⇒ Payload}
-import phoenix.services.LineItemUpdater
 import phoenix.utils.aliases._
 import phoenix.utils.seeds.Factories
 import testutils._
 import testutils.fixtures.BakedFixtures
 import core.db._
+import phoenix.services.carts.CartLineItemUpdater
 
 class LineItemUpdaterTest
     extends IntegrationTestBase
@@ -36,7 +36,7 @@ class LineItemUpdaterTest
       )
 
       val root =
-        LineItemUpdater.updateQuantitiesOnCart(storeAdmin, cart.refNum, payload).gimme.result
+        CartLineItemUpdater.updateQuantitiesOnCart(storeAdmin, cart.refNum, payload).gimme.result
       root.lineItems.skus.count(_.sku == "1") must be(1)
       root.lineItems.skus.count(_.sku == "2") must be(0)
 
@@ -65,7 +65,7 @@ class LineItemUpdaterTest
       )
 
       val root =
-        LineItemUpdater.updateQuantitiesOnCart(storeAdmin, cart.refNum, payload).gimme.result
+        CartLineItemUpdater.updateQuantitiesOnCart(storeAdmin, cart.refNum, payload).gimme.result
       root.lineItems.skus.count(_.sku == "1") must be(1)
       root.lineItems.skus.count(_.sku == "2") must be(0)
       root.lineItems.skus.count(_.sku == "3") must be(1)


### PR DESCRIPTION
Little prep for cleaner diffs further on
- split `LineItemUpdater` into `CartLineItemUpdater` and `OrderLineItemUpdater`
- move them to `services.carts` and `services.orders` packages appropriately