### PR TITLE
Get rid of process.env.BEHIND_NGINX

### DIFF
--- a/ashes/Makefile
+++ b/ashes/Makefile
@@ -4,8 +4,9 @@ header = $(call baseheader, $(1), ashes)
 export PATH := $(CURDIR)/node_modules/.bin:$(PATH)
 SHELL := env PATH=$(PATH) /bin/sh
 
-GIT_REVISION = $(shell git describe --tags --always)
-GIT_COMMIT = $(shell git rev-parse --short HEAD)
+export GIT_REVISION = $(shell git describe --tags --always)
+export GIT_COMMIT = $(shell git rev-parse --short HEAD)
+export URL_PREFIX = /admin
 WEBPACK_PORT = 4001
 
 notify:
@@ -76,11 +77,11 @@ flow:
 
 .PHONY: build-styleguide
 build-styleguide:
-	GIT_COMMIT=$(GIT_COMMIT) styleguidist build --config styleguide/config.styleguide.js
+	styleguidist build --config styleguide/config.styleguide.js
 
 .PHONY: styleguide sg
 styleguide sg:
-	GIT_COMMIT=$(GIT_COMMIT) styleguidist server --config styleguide/config.styleguide.js
+	styleguidist server --config styleguide/config.styleguide.js
 
 # Base ###
 
@@ -98,7 +99,7 @@ nodemon:
 
 .PHONY: build-dev
 build-dev:
-	GIT_REVISION=$(GIT_REVISION) webpack-dev-server \
+	webpack-dev-server \
 	--inline --watch --hot --progress --content-base=build/ --port $(WEBPACK_PORT)
 
 .PHONY: dev d
@@ -109,7 +110,7 @@ dev d:
 
 .PHONY: build-prod
 build-prod:
-	BEHIND_NGINX=${BEHIND_NGINX} GIT_REVISION=$(GIT_REVISION) NODE_ENV=production webpack --progress
+	NODE_ENV=production webpack --progress
 
 .PHONY: prod p
 prod p: clean build-prod
@@ -118,6 +119,5 @@ prod p: clean build-prod
 # Buildkite ###
 
 .PHONY: build
-build: BEHIND_NGINX=true
 build: MSG=Building
 build: notify clean install build-styleguide build-prod

--- a/ashes/config/api.js
+++ b/ashes/config/api.js
@@ -1,23 +1,11 @@
 'use strict';
 
 module.exports = function(env) {
-  const version = 'v1';
-  const loginUri = process.env.BEHIND_NGINX ? '/admin/login' : '/login';
-
-  function auth() {
-    return {
+  return {
+    auth: {
       header: 'JWT',
       cookieName: 'JWT',
-      loginUri: loginUri,
       publicKey: env.public_key,
-    };
-
-  }
-
-  return {
-    host: process.env.API_URL,
-    uri: `${process.env.API_URL}/${version}`,
-    auth: auth(),
-    version: version
+    }
   };
 };

--- a/ashes/server/api/index.js
+++ b/ashes/server/api/index.js
@@ -2,8 +2,11 @@ const proxy = require('koa-proxy');
 const convert = require('koa-convert');
 
 module.exports = function(app) {
-  const config = app.config.api;
   const matchUriRegexp = new RegExp(`^/api/`);
+
+  if (!process.env.API_URL) {
+    return;
+  }
 
   app.use(async function apiHandler(ctx, next) {
     if (ctx.request.url.match(matchUriRegexp)) {
@@ -16,7 +19,7 @@ module.exports = function(app) {
   });
 
   app.use(convert(proxy({
-    host: config.host,
+    host: process.env.API_URL,
     match: matchUriRegexp,
   })));
 };

--- a/ashes/server/app.js
+++ b/ashes/server/app.js
@@ -28,7 +28,7 @@ app.init = co.wrap(function *(env) {
   require(`./middleware`)(app);
 
   // Without nginx we use `api` middleware to proxy api requests to API_URL
-  if (!process.env.BEHIND_NGINX) {
+  if (process.env.API_URL) {
     require(`./api`)(app);
   }
 

--- a/ashes/server/hmr.js
+++ b/ashes/server/hmr.js
@@ -6,6 +6,6 @@ const convert = require('koa-convert');
 module.exports = function(app) {
   app.use(convert(proxy({
     host: `http://localhost:${process.env.WEBPACK_PORT}`,
-    match: /^\/admin/,
+    match: /^\/admin\/.*\.(js|css|woff|svg|ico|json)$/,
   })));
 };

--- a/ashes/server/index.js
+++ b/ashes/server/index.js
@@ -15,17 +15,15 @@ try {
 
 // env Defaults
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-process.env.API_URL = process.env.API_URL || 'http://localhost';
 process.env.GIT_REVISION = rev;
 process.env.PORT = process.env.PORT || 4000;
 
-const basePath = process.env.BEHIND_NGINX ? '/admin' : '';
 const args = [
-  `${clc.blackBright('NODE_ENV:')} ${clc.blue('%s')}, ${clc.blackBright('API_URL:')} ${clc.green('%s')}, ${clc.red('url: http://localhost:%d%s')}`,
+  `${clc.blackBright('NODE_ENV:')} ${clc.blue('%s')}, ${clc.blackBright('API_URL:')}\
+  ${clc.green('%s')}, ${clc.red('url: http://localhost:%d')}`,
   process.env.NODE_ENV,
-  process.env.API_URL,
+  process.env.API_URL || 'Not defined',
   process.env.PORT,
-  basePath,
 ];
 console.log.apply(this, args); // eslint-disable-line no-console
 

--- a/ashes/src/client.js
+++ b/ashes/src/client.js
@@ -69,7 +69,7 @@ const currentUser = get(store.getState(), 'user.current');
 const needLogin = (!currentUser || !window.tokenOk) && isPathRequiredAuth(location.pathname);
 
 if (needLogin) {
-  const loginUri = process.env.BEHIND_NGINX ? '/admin/login' : '/login';
+  const loginUri = `${process.env.URL_PREFIX}/login`;
 
   store.dispatch(push(loginUri));
 }

--- a/ashes/src/components/header/breadcrumb.jsx
+++ b/ashes/src/components/header/breadcrumb.jsx
@@ -11,7 +11,7 @@ import { Link, IndexLink } from 'components/link';
 // styles
 import s from './breadcrumb.css';
 
-const rootPath = process.env.BEHIND_NGINX ? '/admin' : '/';
+const rootPath = process.env.URL_PREFIX;
 
 type Props = {
   routes: Array<any>;

--- a/ashes/src/lib/api.js
+++ b/ashes/src/lib/api.js
@@ -73,7 +73,7 @@ export function request(method, uri, data, options = {}) {
   let error = null;
 
   const unauthorizedHandler = options.unauthorizedHandler ? options.unauthorizedHandler : () => {
-    window.location.href = process.env.BEHIND_NGINX ? '/admin/login' : '/login';
+    window.location.href = `${process.env.URL_PREFIX}/login`;
   };
 
   const abort = _.bind(result.abort, result);

--- a/ashes/src/routes.js
+++ b/ashes/src/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, IndexRoute, IndexRedirect } from 'react-router';
+import { Route, IndexRoute, Redirect, IndexRedirect } from 'react-router';
 
 import Site from './components/site/site';
 import Home from './components/home/home';
@@ -15,13 +15,13 @@ import settingsRoutes from './routes/settings';
 
 import { getClaims } from 'lib/claims';
 
-const rootPath = process.env.BEHIND_NGINX ? '/admin' : '/';
+const rootPath = process.env.URL_PREFIX;
 const indexRedirect = `${rootPath}/orders`;
 
 export default function makeRoutes(jwtToken) {
   const claims = getClaims(jwtToken);
 
-  return (
+  return [
     <Route path={rootPath}>
       <IndexRedirect to={indexRedirect} />
       {authRoutes(claims)}
@@ -35,6 +35,7 @@ export default function makeRoutes(jwtToken) {
         {settingsRoutes(claims)}
       </Route>
       <Route path="*" component={NotFound} />
-    </Route>
-  );
+    </Route>,
+    <Redirect from="*" to={indexRedirect} />
+  ];
 }

--- a/ashes/webpack.config.js
+++ b/ashes/webpack.config.js
@@ -45,8 +45,10 @@ const baseConfig = {
     new webpack.NamedModulesPlugin(),
 
     new webpack.EnvironmentPlugin({
+      // These ↓↓↓ are just default values
       NODE_ENV: 'development',
-      BEHIND_NGINX: false,
+      API_URL: '',
+      URL_PREFIX: '',
       GIT_REVISION: 'unknown'
     }),
 


### PR DESCRIPTION
## What was done

1. Remove `BEHIND_NGINX` env var
2. Add `URL_PREFIX` env var with default value `/admin`
3. NodeJS server now relies on `API_URL` var: if it exist, API proxy middleware used.
4. Add redirections from non-root paths (`/` → `/admin`)
5. Make some workaround for hmr resolve (we have two servers, webpack and koa, and routes now the same `/admin`, so it is harder to decide what to do).