### PR TITLE
Errant comma in highlander.json.j2 broke deployment

### DIFF
--- a/tabernacle/ansible/roles/dev/marathon_groups/templates/highlander.json.j2
+++ b/tabernacle/ansible/roles/dev/marathon_groups/templates/highlander.json.j2
@@ -39,7 +39,7 @@
                 {% include "core-consumers/capture-consumer.json.j2" %},
                 {% include "core-consumers/customer-groups-consumer.json.j2" %},
                 {% include "core-consumers/gift-card-consumer.json.j2" %},
-                {% include "core-consumers/shipments-consumer.json.j2" %},
+                {% include "core-consumers/shipments-consumer.json.j2" %}
             ]
         },
         {


### PR DESCRIPTION
This caused the resulting `highlander.json` to be invalid, so Marathon rejected the request to spin up Marathon Groups.