### PR TITLE
Bug/timeouts in stripe api other try

### DIFF
--- a/phoenix-scala/phoenix/app/phoenix/failures/StripeFailures.scala
+++ b/phoenix-scala/phoenix/app/phoenix/failures/StripeFailures.scala
@@ -19,6 +19,6 @@ object StripeFailures {
   }
 
   case class StripeProcessingFailure(message: String) extends Failure {
-    override def description = s"Failed to process stripe request with error: ${message}"
+    override def description = s"Failed to process stripe request with error: $message"
   }
 }

--- a/phoenix-scala/phoenix/app/phoenix/utils/apis/StripeWrapper.scala
+++ b/phoenix-scala/phoenix/app/phoenix/utils/apis/StripeWrapper.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeoutException
 
 import cats.implicits._
 import com.stripe.exception.{CardException, StripeException}
-import com.stripe.model.{DeletedCard, ExternalAccount, Token, Card => StripeCard, Charge => StripeCharge, Customer => StripeCustomer}
+import com.stripe.model.{DeletedCard, ExternalAccount, Token, Card ⇒ StripeCard, Charge ⇒ StripeCharge, Customer ⇒ StripeCustomer}
 import com.typesafe.scalalogging.LazyLogging
 import core.db._
 import core.failures.{Failures, GeneralFailure}
@@ -121,14 +121,17 @@ class StripeWrapper extends StripeApiWrapper with LazyLogging {
     // TODO: don’t we need to catch Future (and DBIO) failures like that in general? Also handling ExecutionException. See dispatch.EnrichedFuture#either @michalrus
     val timeout = 10.seconds
     val f = try {
-      Await.result(Future(Either.right(action)).recover {
-        case t: CardException if cardExceptionMap.contains(t.getCode) ⇒
-          Either.left(cardExceptionMap(t.getCode).single)
-        case t: StripeException ⇒
-          Either.left(StripeFailure(t).single)
-      }, timeout)
+      Await.result(
+        Future(Either.right(action)).recover {
+          case t: CardException if cardExceptionMap.contains(t.getCode) ⇒
+            Either.left(cardExceptionMap(t.getCode).single)
+          case t: StripeException ⇒
+            Either.left(StripeFailure(t).single)
+        },
+        timeout
+      )
     } catch {
-      case te: TimeoutException => {
+      case te: TimeoutException ⇒ {
         val message = s"Request to Stripe timed out: ${te.getMessage}"
         logger.error(message)
         Either.left(StripeProcessingFailure(message).single)

--- a/phoenix-scala/phoenix/test/unit/utils/apis/StripeApiErrorHandlingTest.scala
+++ b/phoenix-scala/phoenix/test/unit/utils/apis/StripeApiErrorHandlingTest.scala
@@ -34,9 +34,10 @@ class StripeApiErrorHandlingTest extends TestBase { // for Monad[Future]
 
     "catches timeouts in stripe API" in {
       def boom = { Thread.sleep(20000); throw someStripeException }
-      
+
       val result = Await.result(new StripeWrapper().inBlockingPool(boom).runEmptyA.value, Inf)
-      leftValue(result).head must === (StripeProcessingFailure("Request to Stripe timed out: Futures timed out after [10 seconds]"))
+      leftValue(result).head must === (
+        StripeProcessingFailure("Request to Stripe timed out: Futures timed out after [10 seconds]"))
     }
   }
 


### PR DESCRIPTION
refs #2090

This one should fix `503 Service Unavailable` error.

My guess for the scenario is:
- request is received by nginx and proxied to phoenix, nginx timeout timer starts
- phoenix asks stripe to create CC
- request processing on the Stripe side takes too long
- nginx timeout triggers error 503 and sends it to the client
- phoenix receives timeout exception in stripe wrapper and prints `IOException during API request to Stripe` into log file, but client never receives it because of nginx timeout

This PR just *lowers* timeout and adds some error handling to Stripe calls. We still need to figure out *why* stripe calls are failing, but I bet the issue is not in phoenix code, but in our infrastructure